### PR TITLE
Add window during tiling

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -228,7 +228,7 @@ function PaperWM:start()
         self.logger.df("%s for %s", event, window or app)
         focused_window = window -- windowVisible event happens before windowFocused
         local space = Spaces.windowSpaces(window)[1]
-        self:tileSpace(space)
+        if space then self:tileSpace(space) end
     end)
 
     self.window_filter:subscribe({
@@ -322,7 +322,12 @@ function PaperWM:tileSpace(space)
     local anchor_index = index_table[anchor_window:id()]
     if not anchor_index then
         self.logger.e("anchor index not found")
-        return -- bail
+        if self:addWindow(anchor_window) == space then
+            self.logger.d("added missing window")
+            anchor_index = index_table[anchor_window:id()]
+        else
+            return -- bail
+        end
     end
 
     -- get some global coordinates


### PR DESCRIPTION
Sometimes the space is not valid when the windowVisible event callback is called, immediately after a new window is created. PaperWM:addWindow() will bail, but PaperWM:tileSpace() will try to tile this window when the windowFocused event callback happens, shortly afterwards. Since it appears that the window's space is valid once we get to this second callback, try to add the window during PaperWM:tileSpace() and see if the spaces match.