### PR TITLE
Toggle window widths / heights as increments of golden ratio

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -701,8 +701,8 @@ function PaperWM:cycleWindowSize(direction)
     if not focused_window then return end
 
     local function findNewSize(area_size, frame_size)
-        -- calculate pixel widths from ratios
-        local sizes <const> = { 0.38195, 0.5, 0.61804 }
+        -- calculate pixel widths from golden ratio
+        local sizes <const> = { 0.23607, 0.38195, 0.61804 }
         for index, size in ipairs(sizes) do
             sizes[index] = size * area_size
         end


### PR DESCRIPTION
For large screens, the window width radios taken from PaperWM are a little large. Use the golden ratio to calculate window widths that span a more useful range.

Golden ratio is (1 + sqrt(5)) / 2 == 1.618

Window widths are [ 1 / (1.618 ^ 1), 1 / (1.618 ^ 2), 1 / (1.618 ^ 3) ] These are precalculated and stored as constant values.