### PR TITLE
Respect window gap when computing window size

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -706,7 +706,7 @@ function PaperWM:cycleWindowSize(direction)
     local function findNewSize(area_size, frame_size)
         local sizes = {}
         for index, ratio in ipairs(self.window_ratios) do
-            sizes[index] = ratio * area_size
+            sizes[index] = ratio * area_size - (1 - ratio) * self.window_gap
         end
 
         -- find new size

--- a/init.lua
+++ b/init.lua
@@ -706,7 +706,7 @@ function PaperWM:cycleWindowSize(direction)
     local function findNewSize(area_size, frame_size)
         local sizes = {}
         for index, ratio in ipairs(self.window_ratios) do
-            sizes[index] = ratio * area_size - (1 - ratio) * self.window_gap
+            sizes[index] = ratio * (area_size + self.window_gap) - self.window_gap
         end
 
         -- find new size


### PR DESCRIPTION
Ensure that a number of windows with ratios summing to 1 does not result in any scrolling when switching between them. Or in other words, ensure that they fit nicely on the screen.

Examples:

- Two windows, both with ratios 1/2
- Three windows, all with ratios 1/3
- Two windows, one with ratio 2/3 and one with ratio 1/3

Fixes #20 