### PR TITLE
Set screen_margin to 1 pixel and make it configurable

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -100,6 +100,9 @@ PaperWM.window_gap = 8
 -- ratios to use when cycling widths and heights, golden ratio by default
 PaperWM.window_ratios = { 0.23607, 0.38195, 0.61804 }
 
+-- size of the on-screen margin to place off-screen windows
+PaperWM.screen_margin = 1
+
 -- logger
 PaperWM.logger = hs.logger.new(PaperWM.name)
 
@@ -315,10 +318,6 @@ function PaperWM:tileColumn(windows, bounds, h, w, id, h4id)
 end
 
 function PaperWM:tileSpace(space)
-    -- MacOS doesn't allow windows to be moved off screen
-    -- stack windows in a visible margin on either side
-    local screen_margin <const> = 40
-
     if not space or Spaces.spaceType(space) ~= "user" then
         self.logger.e("current space invalid")
         return
@@ -356,8 +355,8 @@ function PaperWM:tileSpace(space)
 
     -- get some global coordinates
     local screen_frame <const> = screen:frame()
-    local left_margin <const> = screen_frame.x + screen_margin
-    local right_margin <const> = screen_frame.x2 - screen_margin
+    local left_margin <const> = screen_frame.x + self.screen_margin
+    local right_margin <const> = screen_frame.x2 - self.screen_margin
     local canvas <const> = getCanvas(screen)
 
     -- make sure anchor window is on screen


### PR DESCRIPTION
MacOS does not allow windows to be fully off-screen. If you move a window off-screen, MacOS will move the edge of the window 40 pixels back on screen. This was the initial value for the screen_margin constant. However, if you move a window so it's edge is less than 40 pixels to the edge of the screen but still on-screen, MacOS will not adjust it. This can be taken down all the way to 1 pixel, the minimum where the edge of the window is still visible on screen.

Make screen_margin a user configurable variable (in case someone wants a different value) but set the default value to 1 pixel.

Tested on a Macbook Pro with MacOS 14.