### PR TITLE
Don't use a reoccurring spaceCheck function when switching spaces

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -239,15 +239,6 @@ local function focusSpace(space, window)
         for i = 1, 3 do Timer.doAfter(i * Window.animationDuration, focusCheck) end
     elseif Spaces.spaceType(space) == "user" then
         leftClick(point) -- if there are no windows and the space is a user space then click
-        -- MacOS will sometimes switch to a another space with a focused window
-        -- Setup a timer to check that the requested space stays active
-        local function spaceCheck()
-            if space ~= Spaces.focusedSpace() then
-                Spaces.gotoSpace(space)
-                leftClick(point)
-            end
-        end
-        for i = 1, 3 do Timer.doAfter(i * Window.animationDuration, spaceCheck) end
     end
 end
 


### PR DESCRIPTION
Rapidly switching spaces can trigger an occurrence of https://github.com/mogenson/PaperWM.spoon/issues/33

Plus, with more testing it doesn't work. If there are no windows on the target space and an active app focused on another space, then no amount of clicking the target space screen or using Mission Control to switch to the target space will take the focus away from the active app.

The space ~= Spaces.focusedSpace() check will always fail.