### PR TITLE
Add a window parameter to moveWindowToSpace()

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1029,8 +1029,9 @@ end
 
 ---move focused window to a Mission Control space
 ---@param index number ID for space
-function PaperWM:moveWindowToSpace(index)
-    local focused_window = Window.focusedWindow()
+---@param window Window|nil optional window to move
+function PaperWM:moveWindowToSpace(index, window)
+    local focused_window = window or Window.focusedWindow()
     if not focused_window then
         self.logger.d("focused window not found")
         return


### PR DESCRIPTION
This allows the PaperWM API to be called externally with a provided window. I use it with a function in my HammerSpoon config that moves all windows for a specific application to a given space.

```
function move_app_windows_to_space(application, index)
    local windows = hs.window.filter.new(application):getWindows()
    for i, window in ipairs(windows or {}) do
        -- give time to process window events between moves
        hs.timer.doAfter(0.1 * i, function()
            PaperWM:moveWindowToSpace(index, window)
        end)
    end
end
```