### PR TITLE
Add Github action to create + update SpoonInstall compatible branch

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -1,0 +1,29 @@
+name: Zip into spoon archive
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  zip-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Make folder
+        run: |
+          mkdir Spoons
+          mkdir PaperWM.spoon
+          cp init.lua PaperWM.spoon
+
+      - name: Create zip
+        run: zip -r -q Spoons/PaperWM.spoon.zip PaperWM.spoon
+
+      - name: Commit and push
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: '["Spoons/PaperWM.spoon.zip --force"]'
+          message: "Bundle into zip"
+          push: origin release --set-upstream --force
+          new_branch: release

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+Spoons/
+Swipe.spoon/
+.DS_Store

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "PaperWM",
+    "desc": "A package to enable a PaperWM like window management style"
+  }
+]


### PR DESCRIPTION
First, thank you so much for making this! I've been missing PaperWM/Niri style management in MacOS, and this is a really great solution

When I was installing it I noticed that there didn't seem to be a way to use the [SpoonInstall](https://www.hammerspoon.org/Spoons/SpoonInstall.html) spoon, which asks for a very specific file structure. This should add a Github action that will let someone setup and install using SpoonInstall, as an alternative for cloning into the ~/.hammerspoon/Spoons directory.

It works by zipping the init.lua file into a new Spoons folder, and then force pushing to another branch with the zipped file- hopefully this means that branch needs as little manual maintenance as possible.

With this setup, it should be as simple as installing SpoonInstall, and making your init.lua along the lines of:

```lua
hs.loadSpoon("SpoonInstall")

spoon.SpoonInstall.repos.PaperWM = {
    url = "https://github.com/mogenson/PaperWM.spoon",
    desc = "PaperWM.spoon repository",
    branch = "release",
}

spoon.SpoonInstall:andUse("PaperWM", {
    repo = "PaperWM",
    config = { screen_margin = 16, window_gap = 2 },
    start = true,
    hotkeys = {
		...
    }
})
```

with this, the next time you reload your config, SpoonInstall should download and start PaperWM.

The docs/docs.json file is pretty much the minimum required info; I haven't looked into what kind of useful things you could put in there yet.

Let me know if you have any concerns/would rather do it an alternate way (or just would rather not support SpoonInstall!) If this works for you, I can also update the readme, I just wouldn't do it before this works the way you'd prefer.