### PR TITLE
Add a floating layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ PaperWM:bindHotkeys({
     slurp_in = {{"alt", "cmd"}, "i"},
     barf_out = {{"alt", "cmd"}, "o"},
 
+    -- move the focused window into / out of the tiling layer
+    toggle_floating = {{"alt", "cmd", "shift"}, "escape"},
+
     -- switch to a new Mission Control space
     switch_space_l = {{"alt", "cmd"}, ","},
     switch_space_r = {{"alt", "cmd"}, "."},


### PR DESCRIPTION
Windows in the floating layer are tracked by their window id in `is_floating`, and persisted across restarts/reloads via `hs.settings`. The new `toggle_floating` action can be used to flip the focused window between floating and tiled state.

Would love any feedback here!

Fixes #24.