### PR TITLE
fit all windows within the bounds of the screen when quitting

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -355,6 +355,11 @@ function PaperWM:stop()
     for _, watcher in pairs(ui_watchers) do watcher:stop() end
     screen_watcher:stop()
 
+    -- fit all windows within the bounds of the screen
+    for _, window in ipairs(self.window_filter:getWindows()) do
+        window:setFrameInScreenBounds()
+    end
+
     return self
 end
 


### PR DESCRIPTION
Call setFrameInScreenBounds on all windows in the window filter when the PaperWM:close() method is called.