### PR TITLE
Try to prevent MacOS from stealing focus away to another window

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -704,6 +704,15 @@ function PaperWM:focusWindow(direction, focused_index)
 
     -- focus new window, windowFocused event will be emited immediately
     new_focused_window:focus()
+
+    -- try to prevent MacOS from stealing focus away to another window
+    Timer.doAfter(Window.animationDuration, function()
+        if Window.focusedWindow() ~= new_focused_window then
+            self.logger.df("refocusing window %s", new_focused_window)
+            new_focused_window:focus()
+        end
+    end)
+
     return new_focused_window
 end
 


### PR DESCRIPTION
Often times, MacOS will steal focus away from one window to another window within the same application. For example, focus a Chrome or Safari window on one monitor, and the focus will quickly switch to another visible Chrome or Safari window on a different monitor.

Start a timer to check the current window focus one animation duration after focusing a window and try to focus the window again if the desired window is not focused.