### PR TITLE
build(workflow): update zip workflow to copy all Lua files

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           mkdir Spoons
           mkdir PaperWM.spoon
-          cp init.lua PaperWM.spoon
+          cp *.lua PaperWM.spoon
 
       - name: Create zip
         run: zip -r -q Spoons/PaperWM.spoon.zip PaperWM.spoon


### PR DESCRIPTION
Hi you have forgot add `mission_control.lua` into `PaperWM.zip`. I have updated the `zip.yml` to include all lua files.