### PR TITLE
Add focused windows not detected by the window filter

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -564,8 +564,13 @@ function PaperWM:tileSpace(space)
 
     local anchor_index = index_table[anchor_window:id()]
     if not anchor_index then
-        self.logger.e("anchor index not found")
-        return -- bail
+        self.logger.df("adding window: %s", anchor_window:title())
+        self:addWindow(anchor_window)
+        anchor_index = index_table[anchor_window:id()]
+        if not anchor_index then
+            self.logger.e("anchor index not found")
+            return -- bail
+        end
     end
 
     -- get some global coordinates


### PR DESCRIPTION
There are some windows (like a Firefox browser window with a new profile) that are not detected by the Hammerspoon window filter. These windows emit no events for being opened, closed, or focused.

These windows are returned by the hs.window.focusedWindow() method if they are the focused window.

If we attempt to tile a space and the focused window is not part of the managed window list. Add it to the window list then. This will allow the new window to be tiled and moved / navigated with keyboard shortcuts. It will not fix the lack of window filter events. That needs more investigation and maybe a Hammerspoon fix.