### PR TITLE
Fix focusing nearby window when a window is removed

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -653,8 +653,8 @@ function PaperWM:refreshWindows()
             local space = self:addWindow(window)
             if space then retile_spaces[space] = true end
         elseif index.space ~= Spaces.windowSpaces(window)[1] then
-            -- move to window list in new space
-            self:removeWindow(window)
+            -- move to window list in new space, don't focus nearby window
+            self:removeWindow(window, true)
             local space = self:addWindow(window)
             if space then retile_spaces[space] = true end
         end
@@ -744,12 +744,9 @@ function PaperWM:removeWindow(remove_window, skip_new_window_focus)
     end
 
     if not skip_new_window_focus then -- find nearby window to focus
-        local focused_window = Window.focusedWindow()
-        if focused_window and remove_window:id() == focused_window:id() then
-            for _, direction in ipairs({
-                Direction.DOWN, Direction.UP, Direction.LEFT, Direction.RIGHT
-            }) do if self:focusWindow(direction, remove_index) then break end end
-        end
+        for _, direction in ipairs({
+            Direction.DOWN, Direction.UP, Direction.LEFT, Direction.RIGHT
+        }) do if self:focusWindow(direction, remove_index) then break end end
     end
 
     -- remove window


### PR DESCRIPTION
When a window is closed on MacOS, another window within the same app will be focused. If there are no other windows in the app, then no window will have focus.

In PaperWM.spoon, we want to focus a nearby window (looking to the left, right, up, and down) when a window is removed.

Logs show that MacOS will sometimes send a windowFocused event (for the new window in same app) BEFORE sending the windowNotVisible and windowDestroyed events. This makes it impossible to 1) check if the removed window had focus and 2) search for nearby windows.

I think we can assume that the only way to close a window on MacOS is from user interaction when the window is focused. We'll default to always searching for a nearby window to focus. There is the skip_new_window_focus parameter that is used to avoid this behavior when we are automatically moving windows around (during refresh or moving a window to a new space).