### PR TITLE
Support window filter allowedScreens filter override

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ PaperWM.window_gap = 10  -- 10px gap on all sides
 PaperWM.window_gap  =  { top = 10, bottom = 8, left = 12, right = 12 } -- Specific gaps per side
 ```
 
-Configure one or many `PaperWM.window_filter:rejectApp("appName")` to ignore specific applications. For example:
+Configure the `PaperWM.window_filter` to set which apps and screens are managed. For example:
 
 ```lua
-PaperWM.window_filter:rejectApp("iStat Menus Status")
-PaperWM.window_filter:rejectApp("Finder")
+PaperWM.window_filter:rejectApp("iStat Menus Status") -- ignore a specific app
+PaperWM.window_filter:setScreens({"Built%-in Retina Display"}) -- list of screens to tile (escape string match characters)
 PaperWM:start() -- restart for new window filter to take effect
 ```
 

--- a/mission_control.lua
+++ b/mission_control.lua
@@ -291,7 +291,7 @@ function MissionControl:focusSpace(space_id, window)
         else
             local point = screen:frame()
             point.x = point.x + (point.w // 2)
-            point.y = point.y - 4
+            point.y = point.y - 1
             repeat
                 mouseClick(point)      -- click on menubar
                 coroutine.yield(false) -- not done
@@ -305,7 +305,7 @@ function MissionControl:focusSpace(space_id, window)
 
     local start_time = Timer.secondsSinceEpoch()
     Timer.doUntil(do_space_focus, function(timer)
-        if Timer.secondsSinceEpoch() - start_time > 4 then timer:stop() end
+        if Timer.secondsSinceEpoch() - start_time > 1 then timer:stop() end
     end, Window.animationDuration)
 end
 


### PR DESCRIPTION
Allow the user to set a list of allowed screens for PaperWM to tile, using the hs.window.filter:setScreens() method. Window events will not be received for windows that are on an ignored screen. When moving a window to or from an ignored screen, check to see whether the screen is allowed before removing, adding, or tiling the window(s) on the screen.