### PR TITLE
ignore windows that are not maximizable

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -722,6 +722,12 @@ function PaperWM:addWindow(add_window)
         return
     end
 
+    -- ignore windows that have a zoom button, but are not maximizable
+    if not add_window:isMaximizable() then
+        self.logger.d("ignoring non-maximizable window")
+        return
+    end
+
     -- check if window is already in window list
     if index_table[add_window:id()] then return end
 


### PR DESCRIPTION
Although these windows have a zoom button, they are probably pop up dialogs or tool tips and most people wouldn't want them to be tiled.