### PR TITLE
Multiple Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,22 @@ PaperWM:bindHotkeys({
     focus_up    = {{"alt", "cmd"}, "up"},
     focus_down  = {{"alt", "cmd"}, "down"},
 
+    -- switch windows by cycling forward/backward
+    -- (forward = down or right, backward = up or left)
+    focus_prev = {{"alt", "cmd"}, "k"},
+    focus_next = {{"alt", "cmd"}, "j"},
+
     -- move windows around in tiled grid
     swap_left  = {{"alt", "cmd", "shift"}, "left"},
     swap_right = {{"alt", "cmd", "shift"}, "right"},
     swap_up    = {{"alt", "cmd", "shift"}, "up"},
     swap_down  = {{"alt", "cmd", "shift"}, "down"},
+
+    -- alternative: swap entire columns, rather than
+    -- individual windows (to be used instead of
+    -- swap_left / swap_right bindings)
+    -- swap_column_left = {{"alt", "cmd", "shift"}, "left"},
+    -- swap_column_right = {{"alt", "cmd", "shift"}, "right"},
 
     -- position and resize focused window
     center_window        = {{"alt", "cmd"}, "c"},
@@ -67,12 +78,27 @@ PaperWM:bindHotkeys({
     cycle_height         = {{"alt", "cmd", "shift"}, "r"},
     reverse_cycle_height = {{"ctrl", "alt", "cmd", "shift"}, "r"},
 
+    -- increase/decrease width
+    increase_width = {{"alt", "cmd"}, "l"},
+    decrease_width = {{"alt", "cmd"}, "h"},
+
     -- move focused window into / out of a column
     slurp_in = {{"alt", "cmd"}, "i"},
     barf_out = {{"alt", "cmd"}, "o"},
 
     -- move the focused window into / out of the tiling layer
     toggle_floating = {{"alt", "cmd", "shift"}, "escape"},
+
+    -- focus the first / second / etc window in the current space
+    focus_window_1 = {{"cmd", "shift"}, "1"},
+    focus_window_2 = {{"cmd", "shift"}, "2"},
+    focus_window_3 = {{"cmd", "shift"}, "3"},
+    focus_window_4 = {{"cmd", "shift"}, "4"},
+    focus_window_5 = {{"cmd", "shift"}, "5"},
+    focus_window_6 = {{"cmd", "shift"}, "6"},
+    focus_window_7 = {{"cmd", "shift"}, "7"},
+    focus_window_8 = {{"cmd", "shift"}, "8"},
+    focus_window_9 = {{"cmd", "shift"}, "9"},
 
     -- switch to a new Mission Control space
     switch_space_l = {{"alt", "cmd"}, ","},

--- a/init.lua
+++ b/init.lua
@@ -923,6 +923,26 @@ function PaperWM:focusWindowDiff(diff)
     new_focused_window:focus()
 end
 
+
+function PaperWM:focusWindowAt(new_index)
+    local screen = Screen.mainScreen()
+    local space = Spaces.activeSpaces()[screen:getUUID()]
+    local columns = window_list[space]
+    if not columns then return end
+
+    local index = 1
+    for col_idx = 1, #columns do
+        column = columns[col_idx]
+        for row_idx = 1, #column do
+            if index == new_index then
+                column[row_idx]:focus()
+                return
+            end
+            index = index + 1
+        end
+    end
+end
+
 ---swap the focused window with a window next to it
 ---if swapping horizontally and the adjacent window is in a column, swap the
 ---entire column. if swapping vertically and the focused window is in a column,
@@ -1624,7 +1644,16 @@ PaperWM.actions = {
     move_window_6 = Fnutils.partial(PaperWM.moveWindowToSpace, PaperWM, 6),
     move_window_7 = Fnutils.partial(PaperWM.moveWindowToSpace, PaperWM, 7),
     move_window_8 = Fnutils.partial(PaperWM.moveWindowToSpace, PaperWM, 8),
-    move_window_9 = Fnutils.partial(PaperWM.moveWindowToSpace, PaperWM, 9)
+    move_window_9 = Fnutils.partial(PaperWM.moveWindowToSpace, PaperWM, 9),
+    focus_window_1 = Fnutils.partial(PaperWM.focusWindowAt, PaperWM, 1),
+    focus_window_2 = Fnutils.partial(PaperWM.focusWindowAt, PaperWM, 2),
+    focus_window_3 = Fnutils.partial(PaperWM.focusWindowAt, PaperWM, 3),
+    focus_window_4 = Fnutils.partial(PaperWM.focusWindowAt, PaperWM, 4),
+    focus_window_5 = Fnutils.partial(PaperWM.focusWindowAt, PaperWM, 5),
+    focus_window_6 = Fnutils.partial(PaperWM.focusWindowAt, PaperWM, 6),
+    focus_window_7 = Fnutils.partial(PaperWM.focusWindowAt, PaperWM, 7),
+    focus_window_8 = Fnutils.partial(PaperWM.focusWindowAt, PaperWM, 8),
+    focus_window_9 = Fnutils.partial(PaperWM.focusWindowAt, PaperWM, 9)
 }
 
 ---bind userdefined hotkeys to PaperWM actions

--- a/init.lua
+++ b/init.lua
@@ -876,6 +876,53 @@ function PaperWM:focusWindow(direction, focused_index)
     return new_focused_window
 end
 
+local function findWindowDiff(diff)
+    local focused_window = Window.focusedWindow()
+    if not focused_window then
+        PaperWM.logger.i("current focused window not found")
+        return
+    end
+
+    -- get focused window index
+    local focused_index = index_table[focused_window:id()]
+
+    if not focused_index then
+        PaperWM.logger.i("focused index not found (diff=" .. diff .. ", window=" .. focused_window:title() .. ")")
+        return
+    end
+
+    -- get new focused window
+    local found_window
+
+    local focused_column = getColumn(focused_index.space, focused_index.col)
+    local new_row_index = focused_index.row + diff
+
+    -- first try above/below in same row
+    local found_window = getWindow(focused_index.space, focused_index.col, focused_index.row + diff)
+
+    if not found_window then
+        -- get the bottom row in the previous column, or the first row in the next column
+        local adjacent_column = getColumn(focused_index.space, focused_index.col + diff)
+        if adjacent_column then
+            local col_idx = 1
+            if diff < 0 then col_idx = #adjacent_column end
+            found_window = adjacent_column[col_idx]
+        end
+    end
+
+    if not found_window then
+        PaperWM.logger.i("new focused window not found (diff=" .. diff .. ", current=" .. focused_window:title() .. ")")
+        return
+    end
+    return found_window
+end
+
+function PaperWM:focusWindowDiff(diff)
+    local new_focused_window = findWindowDiff(diff)
+    if not new_focused_window then return end
+    new_focused_window:focus()
+end
+
 ---swap the focused window with a window next to it
 ---if swapping horizontally and the adjacent window is in a column, swap the
 ---entire column. if swapping vertically and the focused window is in a column,
@@ -1430,6 +1477,8 @@ PaperWM.actions = {
     focus_right = Fnutils.partial(PaperWM.focusWindow, PaperWM, Direction.RIGHT),
     focus_up = Fnutils.partial(PaperWM.focusWindow, PaperWM, Direction.UP),
     focus_down = Fnutils.partial(PaperWM.focusWindow, PaperWM, Direction.DOWN),
+    focus_prev = Fnutils.partial(PaperWM.focusWindowDiff, PaperWM, -1),
+    focus_next = Fnutils.partial(PaperWM.focusWindowDiff, PaperWM, 1),
     swap_left = Fnutils.partial(PaperWM.swapWindows, PaperWM, Direction.LEFT),
     swap_right = Fnutils.partial(PaperWM.swapWindows, PaperWM, Direction.RIGHT),
     swap_up = Fnutils.partial(PaperWM.swapWindows, PaperWM, Direction.UP),

--- a/init.lua
+++ b/init.lua
@@ -1257,6 +1257,40 @@ function PaperWM:cycleWindowSize(direction, cycle_direction)
     self:tileSpace(space)
 end
 
+function PaperWM:increaseWindowSize(direction, scale)
+    -- get current focused window
+    local focused_window = Window.focusedWindow()
+    if not focused_window then
+        self.logger.d("focused window not found")
+        return
+    end
+
+    local canvas = getCanvas(focused_window:screen())
+    local focused_frame = focused_window:frame()
+
+    if direction == Direction.WIDTH then
+        local diff = canvas.w * 0.1 * scale
+        local new_size = math.max(diff, math.min(canvas.w, focused_frame.w + diff))
+
+        focused_frame.w = new_size
+        focused_frame.x = focused_frame.x + ((focused_frame.w - new_size) // 2)
+    elseif direction == Direction.HEIGHT then
+        local diff = canvas.h * 0.1 * scale
+        local new_size = math.max(diff, math.min(canvas.h, focused_frame.h + diff))
+
+        focused_frame.h = new_size
+        focused_frame.y = focused_frame.y -
+            math.max(0, focused_frame.y2 - canvas.y2)
+    end
+
+    -- apply new size
+    self:moveWindow(focused_window, focused_frame)
+
+    -- update layout
+    local space = Spaces.windowSpaces(focused_window)[1]
+    self:tileSpace(space)
+end
+
 ---take the current focused window and move it into the bottom of
 ---the column to the left
 function PaperWM:slurpWindow()
@@ -1561,6 +1595,10 @@ PaperWM.actions = {
     swap_column_right = Fnutils.partial(PaperWM.swapColumns, PaperWM, Direction.RIGHT),
     center_window = Fnutils.partial(PaperWM.centerWindow, PaperWM),
     full_width = Fnutils.partial(PaperWM:toggleWindowFullWidth(), PaperWM),
+    increase_width = Fnutils.partial(PaperWM.increaseWindowSize, PaperWM, Direction.WIDTH, 1),
+    decrease_width = Fnutils.partial(PaperWM.increaseWindowSize, PaperWM, Direction.WIDTH, -1),
+    increase_height = Fnutils.partial(PaperWM.increaseWindowSize, PaperWM, Direction.HEIGHT, 1),
+    decrease_height = Fnutils.partial(PaperWM.increaseWindowSize, PaperWM, Direction.HEIGHT, -1),
     cycle_width = Fnutils.partial(PaperWM.cycleWindowSize, PaperWM, Direction.WIDTH, Direction.ASCENDING),
     cycle_height = Fnutils.partial(PaperWM.cycleWindowSize, PaperWM, Direction.HEIGHT, Direction.ASCENDING),
     reverse_cycle_width = Fnutils.partial(PaperWM.cycleWindowSize, PaperWM, Direction.WIDTH, Direction.DESCENDING),


### PR DESCRIPTION
Thanks for making this extension! I've been running with some modifications for a long time now, I figured it was a good time to contribute them back.

I've broken up each feature into individual commits, so you're free to mix and match. If you prefer I can also break them into multiple PRs.

### add focusWindowDiff

Instead of thinking "do I need to go up/down or left/right", I want to cycle forwards/backwards through my windows. Cycling forwards will go down if there's a window below, or to the top of the next column if there's no window below.

### add swapColumns

Swapping windows feels odd when there's multiple rows in a column - it ends up changing the dimension of windows, and IMO doesn't feel natural. swapColumns swaps entire columns, so a stack of windows doesn't get broken up or resized, and full-height windows don't get shrunk.

### add increaseWindowSize

Maybe this is just habit from using [slinger](https://github.com/timbertson/slinger), but I really like being able to bump the current window width up or down by a bit, and hitting that a few more times to continue shrinking/growing. I find this more natural than cycling through a few different canned sizes.

### add focusWindowAt

I keep my early (leftmost) windows in a consistent order, so this lets me e.g. jump to firefox with Cmd+shift+2.