### PR TITLE
Screen margins (untested WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,17 @@ PaperWM.window_gap = 10  -- 10px gap on all sides
 PaperWM.window_gap  =  { top = 10, bottom = 8, left = 12, right = 12 } -- Specific gaps per side
 ```
 
+Set `PaperWM.screen_edge_margins` to define additional margins around the screen edges, independent of `PaperWM.window_gap`.
+This can be a single number for all sides, or a table specifying
+`top`, `right`, `bottom`, and `left` margins individually.
+
+For example:
+```lua
+PaperWM.screen_edge_margins = 0 -- 0px margin on all sides (default)
+-- or
+PaperWM.screen_edge_margins = { top = 50, right = 20, bottom = 50, left = 20 } -- Specific margins per side
+```
+
 Configure the `PaperWM.window_filter` to set which apps and screens are managed. For example:
 
 ```lua

--- a/init.lua
+++ b/init.lua
@@ -135,6 +135,9 @@ PaperWM.window_ratios = { 0.23607, 0.38195, 0.61804 }
 -- size of the on-screen margin to place off-screen windows
 PaperWM.screen_margin = 1
 
+-- screen edge margins: can be set as a table with top, bottom, left, right values
+PaperWM.screen_edge_margins = { top = 0, right = 0, bottom = 0, left = 0 }
+
 -- number of fingers to detect a horizontal swipe, set to 0 to disable
 PaperWM.swipe_fingers = 0
 
@@ -234,10 +237,10 @@ end
 ---@return Frame
 local function getCanvas(screen)
     local screen_frame = screen:frame()
-    local left_gap = getGap("left")
-    local right_gap = getGap("right")
-    local top_gap = getGap("top")
-    local bottom_gap = getGap("bottom")
+    local left_gap = getGap("left") + (PaperWM.screen_edge_margins.left or 0)
+    local right_gap = getGap("right") + (PaperWM.screen_edge_margins.right or 0)
+    local top_gap = getGap("top") + (PaperWM.screen_edge_margins.top or 0)
+    local bottom_gap = getGap("bottom") + (PaperWM.screen_edge_margins.bottom or 0)
 
     return Rect(
         screen_frame.x + left_gap,


### PR DESCRIPTION
Great work with PaperWM.spoon! I've been a loyal user of PaperWM on my GNOME laptop and I'm so happy to have the same on MacOS as well.

This is a WIP PR but I figured to open it now for feedback :) 

## Context

- I have a big screen (27") and I don't want to use all of it. I want to give it some margins to not use the whole screen.

- I have another ultrawide monitor that is too wide for me. I want margins on the right side of the screen.

## Solution

This implements `screen_edge_margins`.

## Prior art

GNOME PaperWM has this feature as "horizontal margin" (and "top margin" and "bottom margin").

![imagen](https://github.com/user-attachments/assets/a5baa50d-79e7-4f18-86a5-ad0aaf622c08)

