### PR TITLE
Improve refresh windows on screen change and tiling error

### DIFF
--- a/space.lua
+++ b/space.lua
@@ -44,8 +44,9 @@ function Space.tileSpace(space)
 
     local anchor_index = Space.PaperWM.state.index_table[anchor_window:id()]
     if not anchor_index then
-        Space.PaperWM.logger.e("anchor index not found")
-        return -- bail
+        Space.PaperWM.logger.e("anchor index not found, refreshing windows")
+        Space.PaperWM.windows.refreshWindows() -- try refreshing the windows
+        return                                 -- bail
     end
 
     -- get some global coordinates

--- a/windows.lua
+++ b/windows.lua
@@ -533,7 +533,6 @@ end
 ---exchange two columns of windows
 ---@param direction Direction Direction.LEFT or Direction.RIGHT
 function Windows.swapColumns(direction)
-    print("typeof direction ", type(direction), " value ", hs.inspect(direction))
     -- use focused window as source window
     local focused_window = Window.focusedWindow()
     if not focused_window then


### PR DESCRIPTION
Debounce screen change events by scheduling a timer to refresh windows. Screen change events can occur multiple times in a short duration when a monitor is plugged / unplugged, or a laptop lid is opened.

If we try to tile a window that does not have a tiling index (usually because the window is not on a space), refresh the windows to find the space for that window. This usually happens after a screen change or a display size / resolution change.

These changes reduce the number of times I've had to restart the spoon.