### PR TITLE
Handle nil x_positions value in windowUnderCursor

### DIFF
--- a/events.lua
+++ b/events.lua
@@ -238,7 +238,9 @@ function Events.mouseHandler(self)
         if not screen then return end
         local space = Spaces.activeSpaceOnScreen(screen)
         if not space then return end
-        for window, _ in pairs(self.state.x_positions[space]) do if cursor:inside(window:frame()) then return window end end
+        for window, _ in pairs(self.state.x_positions[space] or {}) do
+            if cursor:inside(window:frame()) then return window end
+        end
     end
 
     ---callback for mouse event


### PR DESCRIPTION
Iterate over an empty table if self.state.x_positions[space] returns nil. This should prevent a crash when using the mouse drag hotkey on a space with no windows.