### PR TITLE
Fix and optimize slide windows

### DIFF
--- a/space.lua
+++ b/space.lua
@@ -111,15 +111,18 @@ function Space.tileSpace(space)
     end
 
     -- tile windows from anchor left
-    local x = anchor_frame.x
-    local x2 = math.max(anchor_frame.x - left_gap, left_margin)
+    local x2 = anchor_frame.x - left_gap
     for col = anchor_index.col - 1, 1, -1 do
-        local bounds = { x = nil, x2 = x2, y = canvas.y, y2 = canvas.y2 }
+        local bounds = {
+            x = nil,
+            x2 = math.max(x2, left_margin),
+            y = canvas.y,
+            y2 = canvas.y2,
+        }
         local column = Space.PaperWM.windows.getColumn(space, col)
         local width = Space.PaperWM.windows.tileColumn(column, bounds)
-        x = x - width - left_gap
-        Space.PaperWM.windows.updateVirtualPositions(space, column, x)
-        x2 = math.max(x2 - width - left_gap, left_margin)
+        Space.PaperWM.windows.updateVirtualPositions(space, column, x2 - width)
+        x2 = x2 - width - left_gap
     end
 end
 

--- a/state.lua
+++ b/state.lua
@@ -10,7 +10,7 @@ State.window_list = {} -- 3D array of tiles in order of [space][x][y]
 State.index_table = {} -- dictionary of {space, x, y} with window id for keys
 State.ui_watchers = {} -- dictionary of uielement watchers with window id for keys
 State.is_floating = {} -- dictionary of boolean with window id for keys
-State.x_positions = {} -- dictionary of horizontal positions with [space][window] for keys
+State.x_positions = {} -- dictionary of horizontal positions with [space][id] for keys
 
 State.prev_focused_window = nil ---@type Window|nil
 State.pending_window = nil ---@type Window|nil
@@ -44,8 +44,8 @@ function State.dump()
     table.insert(output, "\nx_positions:")
     for space, positions in pairs(State.x_positions) do
         table.insert(output, string.format("  Space %s:", tostring(space)))
-        for window, x in pairs(positions) do
-            table.insert(output, string.format("    Window %s (%d): x=%d", window:title(), window:id(), x))
+        for id, x in pairs(positions) do
+            table.insert(output, string.format("    Window %s (%d): x=%d", hs.window(id):title(), id, x))
         end
     end
 

--- a/windows.lua
+++ b/windows.lua
@@ -119,12 +119,11 @@ end
 ---@param space Space
 ---@param windows Window[]
 function Windows.updateVirtualPositions(space, windows, x)
-    if Windows.PaperWM.swipe_fingers == 0 then return end
     if not Windows.PaperWM.state.x_positions[space] then
         Windows.PaperWM.state.x_positions[space] = {}
     end
     for _, window in ipairs(windows) do
-        Windows.PaperWM.state.x_positions[space][window] = x
+        Windows.PaperWM.state.x_positions[space][window:id()] = x
     end
 end
 
@@ -310,7 +309,7 @@ function Windows.removeWindow(remove_window, skip_new_window_focus)
     Windows.PaperWM.state.ui_watchers[remove_window:id()] = nil
 
     -- clear window position
-    (Windows.PaperWM.state.x_positions[remove_index.space] or {})[remove_window] = nil
+    (Windows.PaperWM.state.x_positions[remove_index.space] or {})[remove_window:id()] = nil
 
     -- update index table
     Windows.PaperWM.state.index_table[remove_window:id()] = nil


### PR DESCRIPTION
We were previously using hs.window userdata as keys for the state.x_positions table. When stacking windows in a column, Lua decides that the new userdata is different and creates a new entry in the x_positions table instead of updating the window virtual x position. Instead, use integer window IDs for x_position table keys.

Looking up a hs.window from an ID is costly. When a window slide operation starts, cache a list of hs.windows, their virtual x positions, and their frames. Use this cached info to set each window position from a delta x slide update. This way we don't need to call back into MacOS to fetch a window or any window info, and avoid a Lua -> Objective-C bridge. There is a slight initial delay because these window lookup have to be performed sometime, but anecdotally the window sliding behavior is smoother overall.

Finally, if a mouse click or drag event is for a PaperWM.spoon window movement, delete that event so it does not propagate. This prevents MacOS from moving the window or the content of the window when the cursor location and calculated delta x are slightly off.