### PR TITLE
docs: drop-in modal layer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ modal:bind({}, "h", nil, actions.focus_left)
 modal:bind({}, "j", nil, actions.focus_down)
 modal:bind({}, "k", nil, actions.focus_up)
 modal:bind({}, "l", nil, actions.focus_right)
+modal:bind({}, "escape", function() modal:exit() end)
+
+PaperWM:start()
 ```
 
 `PaperWM:start()` will begin automatically tiling new and existing windows.


### PR DESCRIPTION
Changes the example of a hyper key and modal layer in the README to function as described when copied directly to init.lua

This change clarifies the documentation by making it simpler to test out the modal layer functionality. 
The current snippet is not designed to exit when escape is pressed (as stated in the comment) nor does it start PaperWM on its own.
This change removes both of these roadblocks by making this block of code work when copied and pasted on its own into `init.lua`.

Reasoning: When I installed PaperWM.spoon, it took me a few minutes to make this snippet work, and I could see it taking much longer for someone who is new to configuration, so I think this change would benefit new adopters.

The escape binding is taken from the [Hammerspoon documentation](https://www.hammerspoon.org/docs/hs.hotkey.modal.html).