### PR TITLE
Add start_events action

### DIFF
--- a/actions.lua
+++ b/actions.lua
@@ -13,6 +13,7 @@ end
 function Actions.actions()
     local Direction = Actions.PaperWM.windows.Direction
     return {
+        start_events = Fnutils.partial(Actions.PaperWM.start, Actions.PaperWM),
         stop_events = Fnutils.partial(Actions.PaperWM.stop, Actions.PaperWM),
         refresh_windows = Actions.PaperWM.windows.refreshWindows,
         dump_state = Actions.PaperWM.state.dump,


### PR DESCRIPTION
Expose PaperWM:start() as an action that can be bound to a keyboard shortcut. The start_events action enables automatic window tiling and subscribes to window events. The stop_events action disables automatic tiling and unsubscribes from window events.