### PR TITLE
Ensure new windows are placed on screen

### DIFF
--- a/spec/mocks.lua
+++ b/spec/mocks.lua
@@ -11,24 +11,33 @@ end
 
 function M.mock_window(id, title, frame)
     frame = frame or { x = 0, y = 0, w = 100, h = 100 }
-    frame.center = { x = frame.x + frame.w / 2, y = frame.y + frame.h / 2 }
-    frame.x2 = frame.x + frame.w
-    frame.y2 = frame.y + frame.h
+
+    function set_frame(new_frame, bounds)
+        bounds = bounds or new_frame
+        frame.x = new_frame.x > bounds.x and new_frame.x or bounds.x
+        frame.y = new_frame.y > bounds.y and new_frame.y or bounds.y
+        frame.w = frame.x + new_frame.w <= bounds.x + bounds.w and new_frame.w or
+            bounds.x + bounds.w - frame.x
+        frame.h = frame.y + new_frame.h <= bounds.y + bounds.h and new_frame.h or
+            bounds.y + bounds.h - frame.y
+        frame.x2 = frame.x + frame.w
+        frame.y2 = frame.y + frame.h
+        frame.center = { x = frame.x + frame.w / 2, y = frame.y + frame.h / 2 }
+    end
+
+    set_frame(frame)
+
     return {
         id = function() return id end,
         title = function() return title end,
         frame = function() return frame end,
-        application = function() return { bundleID = function() return "com.apple.Terminal" end } end,
+        application = function() return { bundleID = function() return "com.apple.Finder" end } end,
         tabCount = function() return 0 end,
         isMaximizable = function() return true end,
-        newWatcher = function()
-            return {
-                start = function() end,
-                stop = function() end,
-            }
-        end,
+        newWatcher = function() return { start = function() end, stop = function() end } end,
         focus = function() end,
-        setFrame = function(new_frame) frame = new_frame end,
+        setFrame = function(self, new_frame) set_frame(new_frame) end,
+        setFrameInScreenBounds = function(self, new_frame, _) set_frame(new_frame, M.mock_screen().frame()) end,
         screen = function() return M.mock_screen() end,
     }
 end

--- a/windows.lua
+++ b/windows.lua
@@ -165,6 +165,8 @@ function Windows.addWindow(add_window)
         (Windows.PaperWM.state.prev_focused_window:id() ~= add_window:id()) then -- insert to the right
         add_column = Windows.PaperWM.state.windowIndex(Windows.PaperWM.state.prev_focused_window).col + 1
     else
+        -- ensure window is within screen
+        add_window:setFrameInScreenBounds(add_window:frame(), 0)
         local x = add_window:frame().center.x
         for col, windows in ipairs(Windows.PaperWM.state.windowList(space)) do
             if x < windows[1]:frame().center.x then
@@ -181,6 +183,9 @@ function Windows.addWindow(add_window)
 
     -- subscribe to window moved events
     Windows.PaperWM.state.uiWatcherCreate(add_window)
+
+    -- focus new window so it's tiled on screen
+    add_window:focus()
 
     return space
 end


### PR DESCRIPTION
We try our best to insert new windows to the right of the currently focused window and make sure they are on screen. But sometimes we don't know the previously focused window, so we insert the window into an array of tiled windows by position on screen, from left to right.

This is better than appending a new window to the end of the tiled array, or putting it at the beginning or in the middle, because the existing tiled windows will not shift left or right and the new window should be on screen.

But, sometimes the center of the new window is off screen so it it's inserted off screen. Sometimes it's not focused so it's tiled off screen.

Use setFrameInScreenBounds() to make sure the new window is on screen before inserting it into the tiled array. Then, focus the new window after inserting so that the space is tiled and the new window is moved on screen.