### PR TITLE
Fix safari window not part of the flow

### DIFF
--- a/spec/mocks.lua
+++ b/spec/mocks.lua
@@ -9,28 +9,27 @@ function M.mock_screen()
     }
 end
 
-function M.mock_window(id, title, frame, overrides)
-    overrides = overrides or {}
+function M.mock_window(id, title, frame)
     frame = frame or { x = 0, y = 0, w = 100, h = 100 }
     frame.center = { x = frame.x + frame.w / 2, y = frame.y + frame.h / 2 }
     frame.x2 = frame.x + frame.w
     frame.y2 = frame.y + frame.h
     return {
-        id = overrides.id or function() return id end,
-        title = overrides.title or function() return title end,
-        frame = overrides.frame or function() return frame end,
-        application = overrides.application or function() return { bundleID = function() return "com.apple.Terminal" end } end,
-        tabCount = overrides.tabCount or function() return 0 end,
-        isMaximizable = overrides.isMaximizable or function() return true end,
-        newWatcher = overrides.newWatcher or function()
+        id = function() return id end,
+        title = function() return title end,
+        frame = function() return frame end,
+        application = function() return { bundleID = function() return "com.apple.Terminal" end } end,
+        tabCount = function() return 0 end,
+        isMaximizable = function() return true end,
+        newWatcher = function()
             return {
                 start = function() end,
                 stop = function() end,
             }
         end,
-        focus = overrides.focus or function() end,
-        setFrame = overrides.setFrame or function(new_frame) frame = new_frame end,
-        screen = overrides.screen or function() return M.mock_screen() end,
+        focus = function() end,
+        setFrame = function(new_frame) frame = new_frame end,
+        screen = function() return M.mock_screen() end,
     }
 end
 

--- a/spec/windows_spec.lua
+++ b/spec/windows_spec.lua
@@ -42,9 +42,9 @@ describe("PaperWM.windows", function()
         end)
 
         it("should skip Apple windows with tabs", function()
-            local win = mock_window(101, "Test Window", nil, {
-                tabCount = function() return 2 end,
-            })
+            local win = mock_window(101, "Test Window", nil)
+            win.tabCount = function() return 2 end
+            win.application = function() return { bundleID = function() return "com.apple.Finder" end } end
 
             local space = Windows.addWindow(win)
 
@@ -55,10 +55,27 @@ describe("PaperWM.windows", function()
         end)
 
         it("should add Safari windows with tabs", function()
-            local win = mock_window(101, "Test Window", nil, {
-                tabCount = function() return 2 end,
-                application = function() return { bundleID = function() return "com.apple.Safari" end } end,
-            })
+            local win = mock_window(101, "Test Window", nil)
+            win.tabCount = function() return 2 end
+            win.application = function() return { bundleID = function() return "com.apple.Safari" end } end
+
+            local space = Windows.addWindow(win)
+
+            local state = Windows.PaperWM.state.get()
+            assert.are.equal(1, space)
+            assert.are.equal(1, #state.window_list[space])
+            assert.are.equal(1, #state.window_list[space][1])
+            assert.are.equal(win, state.window_list[space][1][1])
+            assert.is_not_nil(state.index_table[101])
+            assert.are.equal(1, state.index_table[101].col)
+            assert.are.equal(1, state.index_table[101].row)
+            assert.is_not_nil(state.ui_watchers[101])
+        end)
+
+        it("non-Apple apps with tabs can be added", function()
+            local win = mock_window(101, "Test Window", nil)
+            win.tabCount = function() return 2 end
+            win.application = function() return { bundleID = function() return "com.Microsoft.Word" end } end
 
             local space = Windows.addWindow(win)
 

--- a/windows.lua
+++ b/windows.lua
@@ -130,7 +130,9 @@ function Windows.addWindow(add_window)
     -- We can't query whether an exiting hs.window is a tab or not after creation
     local apple <const> = "com.apple"
     local safari <const> = "com.apple.Safari"
-    if add_window:tabCount() > 0 and add_window:application():bundleID():sub(1, #apple) == apple and add_window:application():bundleID():sub(1, #safari) ~= safari then
+    if add_window:tabCount() > 0
+        and add_window:application():bundleID():sub(1, #apple) == apple
+        and add_window:application():bundleID():sub(1, #safari) ~= safari then
         -- It's mostly built-in Apple apps like Finder and Terminal whose tabs
         -- show up as separate windows. Third party apps like Microsoft Office
         -- use tabs that are all contained within one window and tile fine.


### PR DESCRIPTION
This is a fix, with associated tests, for issue #72. I'm able to reliably reproduce the issue by creating a Safari window with tabs, minimize it to the dock, then restore it. The code on main pops an alert in this case and ignores the Safari window, but if you simply disable the check you'll notice the code handles the Safari window just fine (it does not produce a weird gap like Terminal does).

The approach I implemented is the most targeted way to specifically handle the issue with Safari, but it could be made more generic such that the user could change it, like the ability to specify a window filter in the config (that turned out to be helpful for me currently; it allows my Quake-style dropdown terminal that I've implemented with Wezterm+Hammerspoon to be ignored). If that's desirable, that could be implemented in a new PR.