### PR TITLE
Add tests and documentation for focus floating action

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ PaperWM:bindHotkeys({
 
     -- move the focused window into / out of the tiling layer
     toggle_floating = {{"alt", "cmd", "shift"}, "escape"},
+    -- raise all floating windows on top of tiled windows
+    focus_floating  = {{"alt", "cmd", "shift"}, "f"},
 
     -- focus the first / second / etc window in the current space
     focus_window_1 = {{"cmd", "shift"}, "1"},

--- a/config.lua
+++ b/config.lua
@@ -9,6 +9,7 @@ Config.default_hotkeys = {
     refresh_windows      = { { "alt", "cmd", "shift" }, "r" },
     dump_state           = { { "alt", "cmd", "shift" }, "d" },
     toggle_floating      = { { "alt", "cmd", "shift" }, "escape" },
+    focus_floating       = { { "alt", "cmd", "shift" }, "f" },
     focus_left           = { { "alt", "cmd" }, "left" },
     focus_right          = { { "alt", "cmd" }, "right" },
     focus_up             = { { "alt", "cmd" }, "up" },

--- a/events.lua
+++ b/events.lua
@@ -45,7 +45,7 @@ function Events.windowEventHandler(window, event, self)
         return
     end
 
-    self.logger.df("%s for [%s] id: %d", event, window:title(), window:id())
+    self.logger.df("%s for [%s]: %d", event, window:title(), window:id())
     local space = nil
 
     --[[ When a new window is created, We first get a windowVisible event but
@@ -72,6 +72,10 @@ function Events.windowEventHandler(window, event, self)
                     self.logger.vf("pending window timer for %s", window)
                     Events.windowEventHandler(window, event, self)
                 end)
+            return
+        end
+        if self.state.prev_focused_window == window then
+            self.logger.df("ignoring already focused window: [%s]: %d", window:title(), window:id())
             return
         end
         self.state.prev_focused_window = window -- for addWindow()

--- a/floating.lua
+++ b/floating.lua
@@ -1,3 +1,4 @@
+local Fnutils <const> = hs.fnutils
 local Window <const> = hs.window
 
 local Floating = {}
@@ -74,16 +75,18 @@ end
 
 ---focus all floating windows that are not minimized or hidden
 function Floating.focusFloating()
-    local windows_to_focus = {}
-    local visible_windows <const> = Window.visibleWindows()
-    for _, window in ipairs(visible_windows) do
-        if not Floating.PaperWM.state.isTiled(window:id()) then
-            table.insert(windows_to_focus, window)
-        end
-    end
+    local focused_window = Window.focusedWindow()
+
+    local windows_to_focus <const> = Fnutils.ifilter(Window.visibleWindows(), function(win)
+        return not Floating.PaperWM.state.isTiled(win:id())
+    end)
+
     for _, window in ipairs(windows_to_focus) do
         window:focus()
     end
+
+    -- restore focus to original window
+    if focused_window then focused_window:focus() end
 end
 
 return Floating

--- a/spec/mocks.lua
+++ b/spec/mocks.lua
@@ -101,6 +101,11 @@ function M.init_mocks(modules)
                     return func(table.unpack(all_args))
                 end
             end,
+            ifilter = function(t, fn)
+                local nt = {}
+                for _, v in ipairs(t) do if fn(v) then nt[#nt + 1] = v end end
+                return nt
+            end,
         },
         logger = {
             new = function(_)

--- a/spec/state_spec.lua
+++ b/spec/state_spec.lua
@@ -1,0 +1,31 @@
+---@diagnostic disable
+
+package.preload["mocks"] = function() return dofile("spec/mocks.lua") end
+package.preload["state"] = function() return dofile("state.lua") end
+
+describe("PaperWM.state", function()
+    local Mocks = require("mocks")
+    Mocks.init_mocks()
+
+    local State = require("state")
+
+    local mock_paperwm = Mocks.get_mock_paperwm({ State = State })
+
+    before_each(function()
+        -- Reset state before each test
+        State.init(mock_paperwm)
+    end)
+
+    describe("isTiled", function()
+        it("should return true for a tiled window and false for a floating window", function()
+            -- To add a window to index_table, we need to add it to window_list
+            local space = 1
+            local win = Mocks.mock_window(123, "Tiled Window")
+            local window_list = State.windowList(space)
+            window_list[1] = { win }
+
+            assert.is_true(State.isTiled(123))
+            assert.is_false(State.isTiled(456))
+        end)
+    end)
+end)

--- a/windows.lua
+++ b/windows.lua
@@ -214,6 +214,11 @@ function Windows.removeWindow(remove_window, skip_new_window_focus)
     -- clear window position
     Windows.PaperWM.state.xPositions(remove_index.space)[remove_window:id()] = nil
 
+    -- clear dangling reference
+    if Windows.PaperWM.state.prev_focused_window == remove_window then
+        Windows.PaperWM.state.prev_focused_window = nil
+    end
+
     return remove_index.space -- return space for removed window
 end
 


### PR DESCRIPTION
Add tests for focusFloating and isTiled methods. Refactor focusFloating a bit by using the Hammerspoon ifilter routine.

Make misc improvements to prevent unnecessary retiling if the same tiled window is focused twice and drop a dangling reference to a previously focused window.