### PR TITLE
Replace existing window when same window is added twice

### DIFF
--- a/windows.lua
+++ b/windows.lua
@@ -148,7 +148,11 @@ function Windows.addWindow(add_window)
     end
 
     -- check if window is already in window list
-    if Windows.PaperWM.state.windowIndex(add_window) then return end
+    local existing_window = Windows.PaperWM.state.windowIndex(add_window)
+    if existing_window then
+        Windows.PaperWM.logger.wf("removing existing window with same id: %d", add_window:id())
+        Windows.removeWindow(existing_window, true)
+    end
 
     local space = Spaces.windowSpaces(add_window)[1]
     if not space then


### PR DESCRIPTION
We currently ignore multiple add window events for the same window. But this might mean the existing window is invalid and tiling can fail when the new ignored window is focused. Replace the existing window with the new window for multiple add window events.