### PR TITLE
Fix focusWindowAt

### DIFF
--- a/spec/mocks.lua
+++ b/spec/mocks.lua
@@ -67,6 +67,7 @@ function M.init_mocks(modules)
             spaceDisplay = function(_) return "mock_screen_uuid" end,
             focusedSpace = function() return 1 end,
             allSpaces = function() return { mock_screen_uuid = { 1, 2, 3 } } end,
+            activeSpaces = function() return { mock_screen_uuid = 1 } end,
         },
         screen = {
             find = function(_) return M.mock_screen() end,

--- a/spec/windows_spec.lua
+++ b/spec/windows_spec.lua
@@ -187,4 +187,39 @@ describe("PaperWM.windows", function()
             assert.are.equal(win1, state.window_list[1][2][1])
         end)
     end)
+
+    describe("focusWindowAt", function()
+        it("should focus the window at the specified index", function()
+            local win1 = mock_window(101, "Window 1")
+            local win2 = mock_window(102, "Window 2")
+            local win3 = mock_window(103, "Window 3")
+
+            -- Setup state: 2 columns. Col 1 has win1, win2. Col 2 has win3.
+            Windows.addWindow(win1)
+            table.insert(State.windowList(1, 1), win2)
+            table.insert(State.windowList(1), { win3 })
+
+            -- spy on focus
+            local s = spy.on(win3, "focus")
+
+            -- win1 is index 1, win2 is index 2, win3 is index 3
+            Windows.focusWindowAt(3)
+
+            assert.spy(s).was.called()
+        end)
+
+        it("should focus the first window", function()
+            local win1 = mock_window(101, "Window 1")
+            local win2 = mock_window(102, "Window 2")
+
+            Windows.addWindow(win1)
+            Windows.addWindow(win2)
+
+            local s = spy.on(win1, "focus")
+
+            Windows.focusWindowAt(1)
+
+            assert.spy(s).was.called()
+        end)
+    end)
 end)

--- a/windows.lua
+++ b/windows.lua
@@ -301,7 +301,7 @@ function Windows.focusWindowAt(n)
     local screen = Screen.mainScreen()
     local space = Spaces.activeSpaces()[screen:getUUID()]
     local columns = Windows.PaperWM.state.windowList(space)
-    if not next(columns) then return end
+    if #columns == 0 then return end
 
     local i = 1
     for col = 1, #columns do


### PR DESCRIPTION
The next() function does not look at a value's metatable. This fails with the column of windows returned from windowList(), since this is an empty table with metamethods for access.

Switch to using the length operator, #, which references the __len metamethod.

Add tests to validate focusWindowAt.