### PR TITLE
Increase tabCount check from >0 to >1

### DIFF
--- a/spec/windows_spec.lua
+++ b/spec/windows_spec.lua
@@ -44,7 +44,7 @@ describe("PaperWM.windows", function()
         it("should skip Apple windows with tabs", function()
             local win = mock_window(101, "Test Window", nil)
             win.tabCount = function() return 2 end
-            win.application = function() return { bundleID = function() return "com.apple.Finder" end } end
+            win.application = function() return { bundleID = function() return "com.apple.Terminal" end } end
 
             local space = Windows.addWindow(win)
 
@@ -52,6 +52,24 @@ describe("PaperWM.windows", function()
             assert.is_nil(space)
             assert.is_nil(state.index_table[101])
             assert.is_nil(state.ui_watchers[101])
+        end)
+
+        it("should add Finder window that reports tabcount of 1", function()
+            local win = mock_window(101, "Test Window", nil)
+            win.tabCount = function() return 1 end
+            win.application = function() return { bundleID = function() return "com.apple.finder" end } end
+
+            local space = Windows.addWindow(win)
+
+            local state = Windows.PaperWM.state.get()
+            assert.are.equal(1, space)
+            assert.are.equal(1, #state.window_list[space])
+            assert.are.equal(1, #state.window_list[space][1])
+            assert.are.equal(win, state.window_list[space][1][1])
+            assert.is_not_nil(state.index_table[101])
+            assert.are.equal(1, state.index_table[101].col)
+            assert.are.equal(1, state.index_table[101].row)
+            assert.is_not_nil(state.ui_watchers[101])
         end)
 
         it("should add Safari windows with tabs", function()

--- a/windows.lua
+++ b/windows.lua
@@ -124,13 +124,13 @@ end
 ---@param add_window Window new window to be added
 ---@return Space|nil space that contains new window
 function Windows.addWindow(add_window)
-    -- A window with no tabs will have a tabCount of 0
+    -- A window with no tabs will have a tabCount of 0 or 1
     -- A new tab for a window will have tabCount equal to the total number of tabs
     -- All existing tabs in a window will have their tabCount reset to 0
     -- We can't query whether an exiting hs.window is a tab or not after creation
     local apple <const> = "com.apple"
     local safari <const> = "com.apple.Safari"
-    if add_window:tabCount() > 0
+    if add_window:tabCount() > 1
         and add_window:application():bundleID():sub(1, #apple) == apple
         and add_window:application():bundleID():sub(1, #safari) ~= safari then
         -- It's mostly built-in Apple apps like Finder and Terminal whose tabs


### PR DESCRIPTION
It seems that some MacOS computers report Finder windows with a tabCount of 1. These windows do not have multiple tabs and tile fine. Increase the tabCount check in addWindow from >0 tabs to >1 tabs. Keep the existing rules about denying com.apple windows with multiple tabs but allow com.apple.Safari windows with multiple tabs.