### PR TITLE
Slide windows with mouse scroll wheel and hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,21 @@ PaperWM.drag_window = { "alt", "cmd" }`
 PaperWM.lift_window = { "alt", "cmd", "shift" }
 ```
 
+### Mouse Scrolling
+
+Spin the mouse scroll wheel while holding the `PaperWM.scroll_window` hotkey to
+slide all windows on a space left or right. Release the hotkey to stop. Change
+`PaperWM.scroll_gain` to a positive or negative number to adjust the direction
+and sensitivity.
+
+```lua
+-- set to a table of modifier keys to enable window scroling, default is nil
+PaperWM.scroll_window = { "alt", "cmd" }`
+
+-- increase move windows further when scrolling, invert to change direction
+PaperWM.scroll_gain = 10.0
+```
+
 ## Limitations
 
 MacOS does not allow a window to be moved fully off-screen. Windows that would

--- a/config.lua
+++ b/config.lua
@@ -55,7 +55,7 @@ Config.window_filter = WindowFilter.new():setOverrideFilter({
     hasTitlebar = true,
     allowRoles = "AXStandardWindow",
 })
--- external bar: make space for external menu bar
+---external bar: make space for external menu bar
 Config.external_bar = nil ---@type {top: number?, bottom: number?}?
 
 ---window gaps: can be set as a single number or a table with top, bottom, left, right values
@@ -73,11 +73,17 @@ Config.swipe_fingers = 0 ---@type number
 ---increase this number to make windows move futher when swiping
 Config.swipe_gain = 1 ---@type number
 
--- set to a table of modifier keys to enable window dragging
-Config.drag_window = nil ---@type string[]|nil e.g. { "alt", "cmd" }`
+---set to a table of modifier keys to enable window dragging
+Config.drag_window = nil ---@type string[]? e.g. { "alt", "cmd" }`
 
--- set to a table of modifier keys to enable window lifting
-Config.lift_window = nil ---@type string[]|nil e.g. { "alt", "cmd", "shift" }
+---set to a table of modifier keys to enable window lifting
+Config.lift_window = nil ---@type string[]? e.g. { "alt", "cmd", "shift" }
+
+---set to a table of modifier keys to enable mouse scrolling
+Config.scroll_window = nil ---@type string[]? e.g. { "alt", "cmd" }
+
+---increase to move windows further when scrolling, negate to invert direction
+Config.scroll_gain = 10 ---@type number
 
 ---center mouse cursor on screen after switching spaces
 Config.center_mouse = true ---@type boolean


### PR DESCRIPTION
Add the option to slide windows on the current space left or right by holding down a hotkey and moving the mouse scroll wheel up or down. Release the hotkey to stop.

This is enabled by setting PaperWM.scroll_window to a set of modifier keys (such as { "alt", "cmd" }). Adjust the PaperWM.scroll_gain to a positive or negative number to control sensitivity and direction (eg. invert the direction for "natural scrolling").