### PR TITLE
Fix tiling after sliding windows

### DIFF
--- a/events.lua
+++ b/events.lua
@@ -156,10 +156,10 @@ local function slide_windows(self, space, screen_frame)
                     self.windows.Direction.RIGHT)
             end
         end)()
-        if visible_window then
-            visible_window:focus()
+        if visible_window and visible_window ~= focused_window then
+            visible_window:focus() -- switching focus will cause space to tile
         else
-            self:tileSpace(space)
+            self:tileSpace(space)  -- retile with same focused window
         end
     else
         self.logger.e("no focused window at end of swipe")


### PR DESCRIPTION
After sliding windows we check if the focused window is on the screen. If all windows are off screen, we focus the closest window to the screen. If this closest window is the focused window, this ends up being a nop because our event handler ignores duplicate focused events for a window.

So, after sliding windows, focus the closet window if it's different from the currently focused window. Otherwise, tile the whole space.