### PR TITLE
Add focus_wrap action and support NEXT and PREVIOUS directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,84 +50,84 @@ Add the following to your `~/.hammerspoon/init.lua`:
 PaperWM = hs.loadSpoon("PaperWM")
 PaperWM:bindHotkeys({
     -- switch to a new focused window in tiled grid
-    focus_left  = {{"alt", "cmd"}, "left"},
-    focus_right = {{"alt", "cmd"}, "right"},
-    focus_up    = {{"alt", "cmd"}, "up"},
-    focus_down  = {{"alt", "cmd"}, "down"},
+    focus_left  = { { "alt", "cmd" }, "left" },
+    focus_right = { { "alt", "cmd" }, "right" },
+    focus_up    = { { "alt", "cmd" }, "up" },
+    focus_down  = { { "alt", "cmd" }, "down" },
 
     -- switch windows by cycling forward/backward
     -- (forward = down or right, backward = up or left)
-    focus_prev = {{"alt", "cmd"}, "k"},
-    focus_next = {{"alt", "cmd"}, "j"},
+    focus_prev = { { "alt", "cmd" }, "k" },
+    focus_next = { { "alt", "cmd" }, "j" },
 
     -- move windows around in tiled grid
-    swap_left  = {{"alt", "cmd", "shift"}, "left"},
-    swap_right = {{"alt", "cmd", "shift"}, "right"},
-    swap_up    = {{"alt", "cmd", "shift"}, "up"},
-    swap_down  = {{"alt", "cmd", "shift"}, "down"},
+    swap_left  = { { "alt", "cmd", "shift" }, "left" },
+    swap_right = { { "alt", "cmd", "shift" }, "right" },
+    swap_up    = { { "alt", "cmd", "shift" }, "up" },
+    swap_down  = { { "alt", "cmd", "shift" }, "down" },
 
     -- position and resize focused window
-    center_window        = {{"alt", "cmd"}, "c"},
-    full_width           = {{"alt", "cmd"}, "f"},
-    cycle_width          = {{"alt", "cmd"}, "r"},
-    reverse_cycle_width  = {{"ctrl", "alt", "cmd"}, "r"},
-    cycle_height         = {{"alt", "cmd", "shift"}, "r"},
-    reverse_cycle_height = {{"ctrl", "alt", "cmd", "shift"}, "r"},
+    center_window        = { { "alt", "cmd" }, "c" },
+    full_width           = { { "alt", "cmd" }, "f" },
+    cycle_width          = { { "alt", "cmd" }, "r" },
+    reverse_cycle_width  = { { "ctrl", "alt", "cmd" }, "r" },
+    cycle_height         = { { "alt", "cmd", "shift" }, "r" },
+    reverse_cycle_height = { { "ctrl", "alt", "cmd", "shift" }, "r" },
 
     -- increase/decrease width
-    increase_width = {{"alt", "cmd"}, "l"},
-    decrease_width = {{"alt", "cmd"}, "h"},
+    increase_width = { { "alt", "cmd" }, "l" },
+    decrease_width = { { "alt", "cmd" }, "h" },
 
     -- move focused window into / out of a column
-    slurp_in = {{"alt", "cmd"}, "i"},
-    barf_out = {{"alt", "cmd"}, "o"},
+    slurp_in = { { "alt", "cmd" }, "i" },
+    barf_out = { { "alt", "cmd" }, "o" },
     
     -- split screen focused window with left window
-    split_screen = {{ "alt", "cmd" }, "s"},
+    split_screen = { { "alt", "cmd" }, "s" },
 
     -- move the focused window into / out of the tiling layer
-    toggle_floating = {{"alt", "cmd", "shift"}, "escape"},
+    toggle_floating = { { "alt", "cmd", "shift" }, "escape" },
     -- raise all floating windows on top of tiled windows
-    focus_floating  = {{"alt", "cmd", "shift"}, "f"},
+    focus_floating  = { { "alt", "cmd", "shift" }, "f" },
 
     -- focus the first / second / etc window in the current space
-    focus_window_1 = {{"cmd", "shift"}, "1"},
-    focus_window_2 = {{"cmd", "shift"}, "2"},
-    focus_window_3 = {{"cmd", "shift"}, "3"},
-    focus_window_4 = {{"cmd", "shift"}, "4"},
-    focus_window_5 = {{"cmd", "shift"}, "5"},
-    focus_window_6 = {{"cmd", "shift"}, "6"},
-    focus_window_7 = {{"cmd", "shift"}, "7"},
-    focus_window_8 = {{"cmd", "shift"}, "8"},
-    focus_window_9 = {{"cmd", "shift"}, "9"},
+    focus_window_1 = { { "cmd", "shift" }, "1" },
+    focus_window_2 = { { "cmd", "shift" }, "2" },
+    focus_window_3 = { { "cmd", "shift" }, "3" },
+    focus_window_4 = { { "cmd", "shift" }, "4" },
+    focus_window_5 = { { "cmd", "shift" }, "5" },
+    focus_window_6 = { { "cmd", "shift" }, "6" },
+    focus_window_7 = { { "cmd", "shift" }, "7" },
+    focus_window_8 = { { "cmd", "shift" }, "8" },
+    focus_window_9 = { { "cmd", "shift" }, "9" },
 
     -- switch to a new Mission Control space
-    switch_space_l = {{"alt", "cmd"}, ","},
-    switch_space_r = {{"alt", "cmd"}, "."},
-    switch_space_1 = {{"alt", "cmd"}, "1"},
-    switch_space_2 = {{"alt", "cmd"}, "2"},
-    switch_space_3 = {{"alt", "cmd"}, "3"},
-    switch_space_4 = {{"alt", "cmd"}, "4"},
-    switch_space_5 = {{"alt", "cmd"}, "5"},
-    switch_space_6 = {{"alt", "cmd"}, "6"},
-    switch_space_7 = {{"alt", "cmd"}, "7"},
-    switch_space_8 = {{"alt", "cmd"}, "8"},
-    switch_space_9 = {{"alt", "cmd"}, "9"},
+    switch_space_l = { { "alt", "cmd" }, "," },
+    switch_space_r = { { "alt", "cmd" }, "." },
+    switch_space_1 = { { "alt", "cmd" }, "1" },
+    switch_space_2 = { { "alt", "cmd" }, "2" },
+    switch_space_3 = { { "alt", "cmd" }, "3" },
+    switch_space_4 = { { "alt", "cmd" }, "4" },
+    switch_space_5 = { { "alt", "cmd" }, "5" },
+    switch_space_6 = { { "alt", "cmd" }, "6" },
+    switch_space_7 = { { "alt", "cmd" }, "7" },
+    switch_space_8 = { { "alt", "cmd" }, "8" },
+    switch_space_9 = { { "alt", "cmd" }, "9" },
 
     -- move focused window to a new space and tile
-    move_window_l = {{ "ctrl", "alt", "cmd" }, "left"},
-    move_window_r = {{ "ctrl", "alt", "cmd" }, "right"},
-    move_window_u = {{ "ctrl", "alt", "cmd" }, "up"},
-    move_window_d = {{ "ctrl", "alt", "cmd" }, "down"},
-    move_window_1 = {{"alt", "cmd", "shift"}, "1"},
-    move_window_2 = {{"alt", "cmd", "shift"}, "2"},
-    move_window_3 = {{"alt", "cmd", "shift"}, "3"},
-    move_window_4 = {{"alt", "cmd", "shift"}, "4"},
-    move_window_5 = {{"alt", "cmd", "shift"}, "5"},
-    move_window_6 = {{"alt", "cmd", "shift"}, "6"},
-    move_window_7 = {{"alt", "cmd", "shift"}, "7"},
-    move_window_8 = {{"alt", "cmd", "shift"}, "8"},
-    move_window_9 = {{"alt", "cmd", "shift"}, "9"}
+    move_window_l = { { "ctrl", "alt", "cmd" }, "left" },
+    move_window_r = { { "ctrl", "alt", "cmd" }, "right" },
+    move_window_u = { { "ctrl", "alt", "cmd" }, "up" },
+    move_window_d = { { "ctrl", "alt", "cmd" }, "down" },
+    move_window_1 = { { "alt", "cmd", "shift" }, "1" },
+    move_window_2 = { { "alt", "cmd", "shift" }, "2" },
+    move_window_3 = { { "alt", "cmd", "shift" }, "3" },
+    move_window_4 = { { "alt", "cmd", "shift" }, "4" },
+    move_window_5 = { { "alt", "cmd", "shift" }, "5" },
+    move_window_6 = { { "alt", "cmd", "shift" }, "6" },
+    move_window_7 = { { "alt", "cmd", "shift" }, "7" },
+    move_window_8 = { { "alt", "cmd", "shift" }, "8" },
+    move_window_9 = { { "alt", "cmd", "shift" }, "9" }
 })
 PaperWM:start()
 ```

--- a/actions.lua
+++ b/actions.lua
@@ -25,6 +25,7 @@ function Actions.actions()
         focus_down = Fnutils.partial(Actions.PaperWM.windows.focusWindow, Direction.DOWN),
         focus_prev = Fnutils.partial(Actions.PaperWM.windows.focusWindow, Direction.PREVIOUS),
         focus_next = Fnutils.partial(Actions.PaperWM.windows.focusWindow, Direction.NEXT),
+        focus_wrap = Actions.PaperWM.windows.focusWrap,
         swap_left = Fnutils.partial(Actions.PaperWM.windows.swapWindows, Direction.LEFT),
         swap_right = Fnutils.partial(Actions.PaperWM.windows.swapWindows, Direction.RIGHT),
         swap_up = Fnutils.partial(Actions.PaperWM.windows.swapWindows, Direction.UP),

--- a/windows.lua
+++ b/windows.lua
@@ -31,7 +31,7 @@ end
 ---return the first window that's completely on the screen
 ---@param space Space space to lookup windows
 ---@param screen_frame Frame the coordinates of the screen
----@pram direction Direction|nil either LEFT or RIGHT
+---@param direction Direction|nil either LEFT or RIGHT
 ---@return Window|nil
 function Windows.getFirstVisibleWindow(space, screen_frame, direction)
     direction = direction or Direction.LEFT
@@ -232,8 +232,43 @@ function Windows.removeWindow(remove_window, skip_new_window_focus)
     return remove_index.space -- return space for removed window
 end
 
+---wrap focus to the opposite side of the screen when trying to move focus past
+---the edge of a row
+---@param direction Direction use either Direction UP, DOWN, LEFT, RIGHT, PREVIOUS, or NEXT
+---@param focused_index Index index of focused window within the windowList
+---@return Window?
+function Windows.focusWrap(direction, focused_index)
+    local new_focused_window = nil
+    if direction == Direction.LEFT or direction == Direction.RIGHT or direction == Direction.PREVIOUS or direction == Direction.NEXT then
+        local columns = Windows.PaperWM.state.windowList(focused_index.space)
+        local num_cols = columns and #columns or 0
+        if num_cols == 1 then
+            return
+        end
+        local leftwards = direction < 0
+        local wrap_col = leftwards and num_cols or 1
+        for row = focused_index.row, 1, -1 do
+            new_focused_window = columns[wrap_col][row]
+            if new_focused_window then
+                local windows = table.remove(columns, wrap_col)
+                table.insert(columns, wrap_col == 1 and num_cols or 1, windows) -- insert wrap column at beginging or end
+                Windows.PaperWM:tileSpace(focused_index.space)                  -- tile before focusing to move wrap column
+                break
+            end
+        end
+    elseif direction == Direction.UP or direction == Direction.DOWN then
+        local column = Windows.PaperWM.state.windowList(focused_index.space, focused_index.col)
+        local num_rows = column and #column or 0
+        if num_rows > 1 then
+            new_focused_window = column[direction == Direction.UP and num_rows or 1]
+        end
+    end
+
+    return new_focused_window
+end
+
 ---move focus to a new window next to the currently focused window
----@param direction Direction use either Direction UP, DOWN, LEFT, or RIGHT
+---@param direction Direction use either Direction UP, DOWN, LEFT, RIGHT, PREVIOUS, or NEXT
 ---@param focused_index Index index of focused window within the windowList
 ---@return Window?
 function Windows.focusWindow(direction, focused_index)
@@ -264,31 +299,14 @@ function Windows.focusWindow(direction, focused_index)
         end
         -- wrap around: if no window found, go to the opposite end
         if not new_focused_window and Windows.PaperWM.infinite_loop_window then
-            local columns = Windows.PaperWM.state.windowList(focused_index.space)
-            local num_cols = columns and #columns or 0
-            if num_cols > 1 then
-                local wrap_col = direction == Direction.LEFT and num_cols or 1
-                for row = focused_index.row, 1, -1 do
-                    new_focused_window = columns[wrap_col][row]
-                    if new_focused_window then
-                        local windows = table.remove(columns, wrap_col)
-                        table.insert(columns, wrap_col == 1 and num_cols or 1, windows) -- insert wrap column at beginging or end
-                        Windows.PaperWM:tileSpace(focused_index.space)                  -- tile before focusing to move wrap column
-                        break
-                    end
-                end
-            end
+            new_focused_window = Windows.focusWrap(direction, focused_index)
         end
     elseif direction == Direction.UP or direction == Direction.DOWN then
         local target_row = focused_index.row + (direction // 2)
         new_focused_window = Windows.PaperWM.state.windowList(focused_index.space, focused_index.col, target_row)
         -- wrap around: if no window found, go to the opposite end
         if not new_focused_window and Windows.PaperWM.infinite_loop_window then
-            local column = Windows.PaperWM.state.windowList(focused_index.space, focused_index.col)
-            local num_rows = column and #column or 0
-            if num_rows > 1 then
-                new_focused_window = column[direction == Direction.UP and num_rows or 1]
-            end
+            new_focused_window = Windows.focusWrap(direction, focused_index)
         end
     elseif direction == Direction.NEXT or direction == Direction.PREVIOUS then
         local diff = direction // Direction.NEXT -- convert to 1/-1
@@ -304,6 +322,8 @@ function Windows.focusWindow(direction, focused_index)
                 local col_idx = 1
                 if diff < 0 then col_idx = #adjacent_column end
                 new_focused_window = adjacent_column[col_idx]
+            elseif Windows.PaperWM.infinite_loop_window then
+                new_focused_window = Windows.focusWrap(direction, focused_index)
             end
         end
     end
@@ -746,13 +766,13 @@ function Windows.splitScreen()
     local left_bounds = {
         x = canvas.x,
         y = canvas.y,
-        y2 = canvas.y2
+        y2 = canvas.y2,
     }
 
     local current_bounds = {
         x = canvas.x + half_width,
         y = canvas.y,
-        y2 = canvas.y2
+        y2 = canvas.y2,
     }
 
     Windows.PaperWM.tiling.tileColumn(left_column, left_bounds, nil, half_width - Windows.PaperWM.windows.getGap("left"))


### PR DESCRIPTION
I have modified #150 to support infinite window looping with the NEXT and PREVIOUS directions, and refactored it as an action in case people want to call it for whatever reason. I have not added my own test cases, but they pass the existing ones. I might do that later.

For what it is worth, I was testing my implementation on my desktop and ran into a sporadic error that crashed the entire window manager:

```
2026-03-19 19:55:00: 19:55:00 ERROR:   LuaSkin: hs.application.watcher callback: /Users/arhan/.hammerspoon/Spoons/PaperWM.spoon/windows.lua:217: assertion failed!
stack traceback:
	[C]: in function 'assert'
	/Users/arhan/.hammerspoon/Spoons/PaperWM.spoon/windows.lua:217: in field 'removeWindow'
	/Users/arhan/.hammerspoon/Spoons/PaperWM.spoon/events.lua:99: in field 'windowEventHandler'
	/Users/arhan/.hammerspoon/Spoons/PaperWM.spoon/events.lua:370: in local 'fn'
	...n.app/Contents/Resources/extensions/hs/window_filter.lua:951: in upvalue 'emit'
	...n.app/Contents/Resources/extensions/hs/window_filter.lua:977: in method 'filterEmitEvent'
	...n.app/Contents/Resources/extensions/hs/window_filter.lua:1011: in method 'emitEvent'
	...n.app/Contents/Resources/extensions/hs/window_filter.lua:1129: in method 'notVisible'
	...n.app/Contents/Resources/extensions/hs/window_filter.lua:1143: in method 'hidden'
	...n.app/Contents/Resources/extensions/hs/window_filter.lua:1328: in function <...n.app/Contents/Resources/extensions/hs/window_filter.lua:1324>
	(...tail calls...)
2026-03-19 19:55:00: 19:55:00 ERROR:   LuaSkin: hs.application.watcher callback: /Users/arhan/.hammerspoon/Spoons/PaperWM.spoon/windows.lua:217: assertion failed!
stack traceback:
	[C]: in function 'assert'
	/Users/arhan/.hammerspoon/Spoons/PaperWM.spoon/windows.lua:217: in field 'removeWindow'
	/Users/arhan/.hammerspoon/Spoons/PaperWM.spoon/events.lua:99: in field 'windowEventHandler'
	/Users/arhan/.hammerspoon/Spoons/PaperWM.spoon/events.lua:370: in local 'fn'
	...n.app/Contents/Resources/extensions/hs/window_filter.lua:951: in upvalue 'emit'
	...n.app/Contents/Resources/extensions/hs/window_filter.lua:977: in method 'filterEmitEvent'
	...n.app/Contents/Resources/extensions/hs/window_filter.lua:1011: in method 'emitEvent'
	...n.app/Contents/Resources/extensions/hs/window_filter.lua:1129: in method 'notVisible'
	...n.app/Contents/Resources/extensions/hs/window_filter.lua:1143: in method 'hidden'
	...n.app/Contents/Resources/extensions/hs/window_filter.lua:1328: in function <...n.app/Contents/Resources/extensions/hs/window_filter.lua:1324>
	(...tail calls...)
2026-03-19 19:55:01: 19:55:01 ERROR:   PaperWM: anchor index not found, refreshing windows
```

So, yeah, I'm not sure if that's related to my changes here or another previously known bug.

(I also fixed the inconsistent spacing in the README in this PR because I didn't think it was worth an entirety separate PR to fix)