### PR TITLE
feat: restore windows to original position & size after PaperWM stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,13 +156,17 @@ modal:bind({}, "h", nil, actions.focus_left)
 modal:bind({}, "j", nil, actions.focus_down)
 modal:bind({}, "k", nil, actions.focus_up)
 modal:bind({}, "l", nil, actions.focus_right)
-modal:bind({}, "escape", function() modal:exit() end)
+modal:bind({}, "escape", function()
+    PaperWM:stop()
+    modal:exit()
+end)
 
 PaperWM:start()
 ```
 
 `PaperWM:start()` will begin automatically tiling new and existing windows.
-`PaperWM:stop()` will release control over windows.
+`PaperWM:stop()` will release control over windows and restore the window 
+to its original position and size after PaperWM stop.
 
 Set `PaperWM.window_gap` to the number of pixels between windows and screen
 edges. This can be a single number for all sides, or a table specifying `top`,

--- a/init.lua
+++ b/init.lua
@@ -101,8 +101,8 @@ function PaperWM:start()
             "please check 'Displays have separate Spaces' in System Preferences -> Mission Control")
     end
 
-	-- windowRestore_afterStop: save current window frames before tiling takes effect
-	self.window_restore.saveWindowFrames()
+    -- windowRestore_afterStop: save current window frames before tiling takes effect
+    self.window_restore.saveWindowFrames()
 
     -- clear state
     self.state.clear();
@@ -125,10 +125,10 @@ function PaperWM:stop()
     -- stop events
     self.events.stop()
 
-	-- windowRestore_afterStop: restore window frames to their pre-tiling positions
-	self.window_restore.restoreWindowFrames()
+    -- windowRestore_afterStop: restore window frames to their pre-tiling positions
+    self.window_restore.restoreWindowFrames()
 
-	-- ensure any window without a saved frame stays within screen bounds
+    -- ensure any window without a saved frame stays within screen bounds
     for _, window in ipairs(self.window_filter:getWindows()) do
         window:setFrameInScreenBounds()
     end

--- a/init.lua
+++ b/init.lua
@@ -73,6 +73,8 @@ PaperWM.events = dofile(hs.spoons.resourcePath("events.lua"))
 PaperWM.actions = dofile(hs.spoons.resourcePath("actions.lua"))
 PaperWM.floating = dofile(hs.spoons.resourcePath("floating.lua"))
 PaperWM.tiling = dofile(hs.spoons.resourcePath("tiling.lua"))
+-- windowRestore_afterStop
+PaperWM.window_restore = dofile(hs.spoons.resourcePath("window_restore.lua"))
 
 -- Initialize modules
 PaperWM.windows.init(PaperWM)
@@ -81,7 +83,9 @@ PaperWM.events.init(PaperWM)
 PaperWM.actions.init(PaperWM)
 PaperWM.state.init(PaperWM)
 PaperWM.floating.init(PaperWM)
-PaperWM.tiling.init(PaperWM)
+PaperWM.tiling.init(PaperWM) 
+-- windowRestore_afterStop
+PaperWM.window_restore.init(PaperWM)
 
 -- Apply config
 for k, v in pairs(PaperWM.config) do
@@ -96,6 +100,9 @@ function PaperWM:start()
         self.logger.e(
             "please check 'Displays have separate Spaces' in System Preferences -> Mission Control")
     end
+
+	-- windowRestore_afterStop: save current window frames before tiling takes effect
+	self.window_restore.saveWindowFrames()
 
     -- clear state
     self.state.clear();
@@ -118,7 +125,10 @@ function PaperWM:stop()
     -- stop events
     self.events.stop()
 
-    -- fit all windows within the bounds of the screen
+	-- windowRestore_afterStop: restore window frames to their pre-tiling positions
+	self.window_restore.restoreWindowFrames()
+
+	-- ensure any window without a saved frame stays within screen bounds
     for _, window in ipairs(self.window_filter:getWindows()) do
         window:setFrameInScreenBounds()
     end

--- a/spec/mocks.lua
+++ b/spec/mocks.lua
@@ -29,7 +29,10 @@ function M.mock_window(id, title, frame)
             }
         end,
         focus = function() end,
-        setFrame = function(new_frame) frame = new_frame end,
+		-- Support both win:setFrame(f) (passes self as first arg) and win.setFrame(f)
+		setFrame = function(self_or_frame, maybe_frame)
+			frame = maybe_frame ~= nil and maybe_frame or self_or_frame
+		end,
         screen = function() return M.mock_screen() end,
     }
 end

--- a/spec/window_restore_spec.lua
+++ b/spec/window_restore_spec.lua
@@ -1,0 +1,196 @@
+---@diagnostic disable
+
+package.preload["mocks"] = function() return dofile("spec/mocks.lua") end
+
+describe("PaperWM.window_restore", function()
+    local Mocks = require("mocks")
+    Mocks.init_mocks()
+
+    local spy = require("luassert.spy")
+
+    local WindowRestore = dofile("window_restore.lua")
+    local mock_window = Mocks.mock_window
+
+    local settings_store
+    local mock_paperwm
+
+    before_each(function()
+        -- stateful settings mock so get() returns what set() stored
+        settings_store = {}
+        hs.settings.set = function(key, value) settings_store[key] = value end
+        hs.settings.get = function(key) return settings_store[key] end
+
+        -- reset module's in-memory snapshot
+        WindowRestore._saved = nil
+
+        mock_paperwm = {
+            window_filter = { getWindows = function() return {} end },
+            logger = { d = function() end, e = function() end },
+        }
+        WindowRestore.init(mock_paperwm)
+    end)
+
+    -- -------------------------------------------------------------------------
+    describe("saveWindowFrames", function()
+        it("saves nothing when there are no managed windows", function()
+            WindowRestore.saveWindowFrames()
+            assert.are.equal(0, #settings_store["PaperWM_saved_frames"])
+        end)
+
+        it("saves one entry per managed window", function()
+            local win1 = mock_window(101, "Window 1", { x = 10, y = 20, w = 300, h = 200 })
+            local win2 = mock_window(102, "Window 2", { x = 50, y = 60, w = 400, h = 300 })
+            mock_paperwm.window_filter.getWindows = function() return { win1, win2 } end
+
+            WindowRestore.saveWindowFrames()
+
+            assert.are.equal(2, #settings_store["PaperWM_saved_frames"])
+        end)
+
+        it("records correct frame coordinates", function()
+            local win = mock_window(101, "Window 1", { x = 10, y = 20, w = 300, h = 200 })
+            mock_paperwm.window_filter.getWindows = function() return { win } end
+
+            WindowRestore.saveWindowFrames()
+
+            local entry = settings_store["PaperWM_saved_frames"][1]
+            assert.are.equal(10,  entry.frame.x)
+            assert.are.equal(20,  entry.frame.y)
+            assert.are.equal(300, entry.frame.w)
+            assert.are.equal(200, entry.frame.h)
+        end)
+
+        it("stores the window ID for same-session matching", function()
+            local win = mock_window(101, "Window 1")
+            mock_paperwm.window_filter.getWindows = function() return { win } end
+
+            WindowRestore.saveWindowFrames()
+
+            local entry = settings_store["PaperWM_saved_frames"][1]
+            assert.are.equal(101, entry.id)
+        end)
+
+        it("stores a stable bundleID|title key for cross-session matching", function()
+            local win = mock_window(101, "Window 1")
+            mock_paperwm.window_filter.getWindows = function() return { win } end
+
+            WindowRestore.saveWindowFrames()
+
+            local entry = settings_store["PaperWM_saved_frames"][1]
+            assert.are.equal("com.apple.Terminal|Window 1", entry.key)
+        end)
+
+        it("keeps an in-memory snapshot in _saved", function()
+            local win = mock_window(101, "Window 1")
+            mock_paperwm.window_filter.getWindows = function() return { win } end
+
+            WindowRestore.saveWindowFrames()
+
+            assert.is_not_nil(WindowRestore._saved)
+            assert.are.equal(1, #WindowRestore._saved)
+        end)
+
+        it("snapshot is independent of later frame mutations", function()
+            local win = mock_window(101, "Window 1", { x = 10, y = 20, w = 300, h = 200 })
+            mock_paperwm.window_filter.getWindows = function() return { win } end
+
+            WindowRestore.saveWindowFrames()
+
+            -- mutate the live frame after saving
+            win:frame().x = 999
+
+            local entry = WindowRestore._saved[1]
+            assert.are.equal(10, entry.frame.x)
+        end)
+    end)
+
+    -- -------------------------------------------------------------------------
+    describe("restoreWindowFrames", function()
+        it("does nothing when no frames have been saved", function()
+            local win = mock_window(101, "Window 1")
+            win.setFrame = spy.new(win.setFrame)
+            mock_paperwm.window_filter.getWindows = function() return { win } end
+
+            WindowRestore.restoreWindowFrames()
+
+            assert.spy(win.setFrame).was.not_called()
+        end)
+
+        it("restores saved frame by window ID within the same session", function()
+            local win = mock_window(101, "Window 1", { x = 10, y = 20, w = 300, h = 200 })
+            mock_paperwm.window_filter.getWindows = function() return { win } end
+            WindowRestore.saveWindowFrames()
+
+            -- simulate PaperWM tiling the window to a different position
+            win:setFrame({ x = 0, y = 32, w = 1000, h = 668 })
+
+            WindowRestore.restoreWindowFrames()
+
+            local restored = win:frame()
+            assert.are.equal(10,  restored.x)
+            assert.are.equal(20,  restored.y)
+            assert.are.equal(300, restored.w)
+            assert.are.equal(200, restored.h)
+        end)
+
+        it("falls back to stable key matching after a session restart", function()
+            -- pre-populate settings as if written by a previous session
+            settings_store["PaperWM_saved_frames"] = {
+                { key = "com.apple.Terminal|My Window", id = nil,
+                  frame = { x = 100, y = 200, w = 800, h = 600 } }
+            }
+            -- _saved is nil: simulates a fresh Hammerspoon session
+
+            local win = mock_window(999, "My Window", { x = 0, y = 0, w = 100, h = 100 })
+            mock_paperwm.window_filter.getWindows = function() return { win } end
+
+            WindowRestore.restoreWindowFrames()
+
+            local restored = win:frame()
+            assert.are.equal(100, restored.x)
+            assert.are.equal(200, restored.y)
+            assert.are.equal(800, restored.w)
+            assert.are.equal(600, restored.h)
+        end)
+
+        it("does not move windows that have no saved entry", function()
+            local win_saved   = mock_window(101, "Saved",  { x = 10, y = 20, w = 300, h = 200 })
+            local win_unsaved = mock_window(102, "Unsaved", { x = 50, y = 60, w = 400, h = 300 })
+            mock_paperwm.window_filter.getWindows = function() return { win_saved } end
+            WindowRestore.saveWindowFrames()
+
+            mock_paperwm.window_filter.getWindows = function() return { win_saved, win_unsaved } end
+            win_unsaved.setFrame = spy.new(win_unsaved.setFrame)
+
+            WindowRestore.restoreWindowFrames()
+
+            assert.spy(win_unsaved.setFrame).was.not_called()
+        end)
+
+        it("consumes duplicate stable keys in order so each window gets a distinct frame", function()
+            settings_store["PaperWM_saved_frames"] = {
+                { key = "com.apple.Terminal|Tab", id = nil, frame = { x = 0,   y = 0, w = 400, h = 300 } },
+                { key = "com.apple.Terminal|Tab", id = nil, frame = { x = 500, y = 0, w = 400, h = 300 } },
+            }
+
+            local win1 = mock_window(1, "Tab", { x = 999, y = 0, w = 100, h = 100 })
+            local win2 = mock_window(2, "Tab", { x = 999, y = 0, w = 100, h = 100 })
+            mock_paperwm.window_filter.getWindows = function() return { win1, win2 } end
+
+            WindowRestore.restoreWindowFrames()
+
+            assert.are.equal(0,   win1:frame().x)
+            assert.are.equal(500, win2:frame().x)
+        end)
+
+        it("clears the in-memory snapshot after restore", function()
+            local win = mock_window(101, "Window 1")
+            mock_paperwm.window_filter.getWindows = function() return { win } end
+            WindowRestore.saveWindowFrames()
+
+            assert.is_not_nil(WindowRestore._saved)
+            WindowRestore.restoreWindowFrames()
+            assert.is_nil(WindowRestore._saved)
+        end)
+    end)
+end)

--- a/window_restore.lua
+++ b/window_restore.lua
@@ -1,0 +1,110 @@
+local Window <const> = hs.window
+
+local WindowRestore = {}
+WindowRestore.__index = WindowRestore
+
+---hs.settings key for persisting saved window frames
+local SavedFramesKey <const> = "PaperWM_saved_frames"
+
+---initialize module with reference to PaperWM
+---@param paperwm PaperWM
+function WindowRestore.init(paperwm)
+    WindowRestore.PaperWM = paperwm
+end
+
+---generate a stable string key for a window across sessions
+---uses bundle ID + title so the key survives Hammerspoon restarts
+---@param window Window
+---@return string
+local function windowKey(window)
+    local app = window:application()
+    local bundle = (app and app:bundleID()) or "unknown"
+    return bundle .. "|" .. (window:title() or "")
+end
+
+---save the frame of every window currently managed by PaperWM
+---called at the beginning of start(), before tiling takes effect
+function WindowRestore.saveWindowFrames()
+    local paperwm = WindowRestore.PaperWM
+    local windows = paperwm.window_filter:getWindows()
+
+    local saved = {}
+    for _, window in ipairs(windows) do
+        local frame = window:frame()
+        local screen = window:screen()
+        table.insert(saved, {
+            key      = windowKey(window),
+            id       = window:id(),
+            frame    = { x = frame.x, y = frame.y, w = frame.w, h = frame.h },
+            screen_id = screen and screen:getUUID() or nil,
+        })
+    end
+
+    -- persist to settings for cross-session restore
+    hs.settings.set(SavedFramesKey, saved)
+    -- keep in memory for same-session restore (avoids re-serialisation round-trip)
+    WindowRestore._saved = saved
+
+    paperwm.logger.d("WindowRestore: saved " .. #saved .. " window frames")
+end
+
+---restore every managed window to its frame saved by saveWindowFrames()
+---called at the end of stop(), after tiling is released
+function WindowRestore.restoreWindowFrames()
+    local paperwm = WindowRestore.PaperWM
+
+    -- prefer in-memory snapshot (same session); fall back to persisted data
+    local saved = WindowRestore._saved or hs.settings.get(SavedFramesKey)
+    if not saved or #saved == 0 then
+        paperwm.logger.d("WindowRestore: no saved frames to restore")
+        return
+    end
+
+    -- build lookup by window ID for same-session matching (fast, exact)
+    local by_id = {}
+    for _, entry in ipairs(saved) do
+        if entry.id then
+            by_id[entry.id] = entry
+        end
+    end
+
+    -- build lookup by stable key for cross-session matching
+    -- multiple entries with the same key are consumed in order
+    local by_key = {}
+    for _, entry in ipairs(saved) do
+        if not by_key[entry.key] then
+            by_key[entry.key] = {}
+        end
+        table.insert(by_key[entry.key], entry)
+    end
+
+    local count = 0
+    local windows = paperwm.window_filter:getWindows()
+    for _, window in ipairs(windows) do
+        -- same-session: match by window ID (most reliable)
+        local entry = by_id[window:id()]
+
+        -- cross-session fallback: match by bundle + title
+        if not entry then
+            local key = windowKey(window)
+            local entries = by_key[key]
+            if entries and #entries > 0 then
+                entry = table.remove(entries, 1)
+            end
+        end
+
+        if entry then
+            local f = entry.frame
+            window:setFrame(hs.geometry.rect(f.x, f.y, f.w, f.h))
+            count = count + 1
+        end
+    end
+
+    paperwm.logger.d("WindowRestore: restored " .. count .. " window frames")
+
+    -- discard in-memory snapshot; persisted copy remains in hs.settings
+    -- so the next start() can still use it if Hammerspoon restarted
+    WindowRestore._saved = nil
+end
+
+return WindowRestore


### PR DESCRIPTION
Hi, 
I had a new idea during use. When i stop paperwm or quit hammerspoon,windows released control, but not restored to original position & size after stop or quit.
So i submitted this request. I'm not sure if this request is necessary.

The following are the relevant code changes.

**New Files** `window_restore.lua`

Core module with two functions:

- saveWindowFrames() — Iterates all windows managed by PaperWM 
and saves each window's {x, y, w, h}, window ID, 
and a stable bundleID|title key to both an in-memory snapshot (_saved)
and hs.settings (key: PaperWM_saved_frames)
- restoreWindowFrames() — Restores each window's frame by matching on window ID first (same session), 
falling back to bundleID|title (cross-session / after Hammerspoon restart).
Clears the in-memory snapshot after restore

**Modified Files** 
`init.lua`

- load window_restore.lua and call init() 
- start() - call saveWindowFrames() before state.clear()
- stop() - call restoreWindowFrames() after events.stop()

`spec/mocks.lua`
Fixed the setFrame method in mock_window. The original function(new_frame) signature incorrectly received self as the first argument when called as win:setFrame(f), causing the
actual frame to be discarded. Fixed to:
```lua
  setFrame = function(self_or_frame, maybe_frame)
      frame = maybe_frame ~= nil and maybe_frame or self_or_frame
  end,
```

**New Test File** `spec/window_restore_spec.lua`

13 tests across two suites:

`saveWindowFrames` (6 tests)
  - Saves an empty list when there are no managed windows
  - Saves one entry per managed window
  - Records correct x, y, w, h coordinates
  - Stores the window ID for same-session matching
  - Stores a stable bundleID|title key for cross-session matching
  - In-memory snapshot is independent of frame mutations after saving

`restoreWindowFrames` (7 tests)
  - Does not call setFrame when no frames have been saved
  - Restores frames correctly by window ID (same session)
  - Restores frames correctly by stable key (cross-session)
  - Does not move windows that have no saved entry
  - Consumes duplicate stable keys in order so each window gets a distinct frame
  - Clears the in-memory snapshot after restore

So users can change their `init.lua` with this to restore windows to original position & size after PaperWM stop
```lua
modal:bind({}, "escape", function()
    PaperWM:stop()
    modal:exit()
end)
```  