### PR TITLE
don't tile windows in event handler

### DIFF
--- a/events.lua
+++ b/events.lua
@@ -104,7 +104,11 @@ function Events.windowEventHandler(window, event, self)
         space = Spaces.windowSpaces(window)[1]
     end
 
-    if space then self:tileSpace(space) end
+    -- schedule tileSpace in a callback to allow global state, like
+    -- Window:focusedWindow(), to update after this event handler
+    if space then
+        Timer.doAfter(Window.animationDuration, function() self:tileSpace(space) end)
+    end
 end
 
 ---coroutine to slide all windows in a space by dx

--- a/state.lua
+++ b/state.lua
@@ -205,7 +205,8 @@ function State.dump()
     for space, positions in pairs(x_positions) do
         table.insert(output, string.format("  Space %s:", tostring(space)))
         for id, x in pairs(positions) do
-            table.insert(output, string.format("    Window %s (%d): x=%d", hs.window(id):title(), id, x))
+            local window = hs.window(id)
+            table.insert(output, string.format("    Window %s (%d): x=%d", window and window:title() or "nil", id, x))
         end
     end
 

--- a/tiling.lua
+++ b/tiling.lua
@@ -80,8 +80,8 @@ function Tiling.tileSpace(space)
     end
 
     -- if focused window is in space, tile from that
-    local focused_window = Window.focusedWindow()
     local anchor_window = (function()
+        local focused_window = Window.focusedWindow()
         if focused_window and not Tiling.PaperWM.floating.isFloating(focused_window) and Spaces.windowSpaces(focused_window)[1] == space then
             return focused_window
         else
@@ -93,6 +93,8 @@ function Tiling.tileSpace(space)
         Tiling.PaperWM.logger.e("no anchor window in space")
         return
     end
+
+    Tiling.PaperWM.logger.df("tiling from anchor window: %s (%d)", anchor_window:title(), anchor_window:id())
 
     local anchor_index = Tiling.PaperWM.state.windowIndex(anchor_window)
     if not anchor_index then

--- a/windows.lua
+++ b/windows.lua
@@ -236,6 +236,8 @@ function Windows.addWindow(add_window)
     -- subscribe to window moved events
     Windows.PaperWM.state.uiWatcherCreate(add_window)
 
+    Windows.PaperWM.logger.df("adding window: %s (%d)", add_window:title(), add_window:id())
+
     return space
 end
 
@@ -258,9 +260,11 @@ function Windows.removeWindow(remove_window, skip_new_window_focus)
     end
 
     -- remove window
-    assert(remove_window == table.remove(
-        Windows.PaperWM.state.windowList(remove_index.space, remove_index.col), remove_index.row)
-    )
+    if remove_window ~= table.remove(
+            Windows.PaperWM.state.windowList(remove_index.space, remove_index.col), remove_index.row)
+    then
+        Windows.PaperWM.logger.ef("removed window %s (%d) doesn't match", remove_window:title(), remove_window:id())
+    end
 
     -- remove watcher
     Windows.PaperWM.state.uiWatcherDelete(remove_window:id())
@@ -272,6 +276,8 @@ function Windows.removeWindow(remove_window, skip_new_window_focus)
     if Windows.PaperWM.state.prev_focused_window == remove_window then
         Windows.PaperWM.state.prev_focused_window = nil
     end
+
+    Windows.PaperWM.logger.df("removing window: %s (%d)", remove_window:title(), remove_window:id())
 
     return remove_index.space -- return space for removed window
 end
@@ -845,13 +851,13 @@ function Windows.splitScreen()
     local left_bounds = {
         x = canvas.x,
         y = canvas.y,
-        y2 = canvas.y2
+        y2 = canvas.y2,
     }
 
     local current_bounds = {
         x = canvas.x + half_width,
         y = canvas.y,
-        y2 = canvas.y2
+        y2 = canvas.y2,
     }
 
     Windows.PaperWM.tiling.tileColumn(left_column, left_bounds, nil, half_width - Windows.PaperWM.windows.getGap("left"))


### PR DESCRIPTION
Currently we call tileSpace() in the event handler. This runs before some Hammerspoon global state gets updated. Notably the hs.window.focusedWindow() method will not return the same window from the present "focusedWindow" event. This causes tileSpace() to select a non-focused window for the anchor window.

Do tileSpace() in a timer callback shortly after the event handler has returned.

Also add a few miscellaneous stability fixes:
- Check window title before printing in state.dump()
- Don't assert in removeWindow(), print an error message instead
- Add debug logs for addWindow(), removeWindow(), and tileSpace()