### PR TITLE
[FEAT]: add hook to allow tiling selected non-maximizable windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,17 @@ PaperWM.app_widths = {
 }
 ```
 
+Some applications report windows as non-maximizable even though those windows can
+still be tiled correctly. Set `PaperWM.allow_non_maximizable_window` to opt in
+specific windows:
+
+```lua
+PaperWM.allow_non_maximizable_window = function(window)
+    local app = window:application()
+    return app and app:bundleID() == "net.imput.helium"
+end
+```
+
 ### Smooth Scrolling
 
 https://github.com/user-attachments/assets/6f1c4659-0ca8-4ba1-a181-8c1c6987e8ef

--- a/config.lua
+++ b/config.lua
@@ -77,6 +77,9 @@ Config.default_width = nil ---@type number?
 ---default window width by app name or bundle ID
 Config.app_widths = {} ---@type table<string, number>
 
+---optional hook to allow specific non-maximizable windows to be tiled
+Config.allow_non_maximizable_window = nil ---@type fun(window: Window): boolean
+
 ---size of the on-screen margin to place off-screen windows
 Config.screen_margin = 1 ---@type number
 

--- a/windows.lua
+++ b/windows.lua
@@ -184,7 +184,9 @@ function Windows.addWindow(add_window)
     end
 
     -- ignore windows that have a zoom button, but are not maximizable
-    if not add_window:isMaximizable() then
+    local allow_non_maximizable = Windows.PaperWM.allow_non_maximizable_window
+        and Windows.PaperWM.allow_non_maximizable_window(add_window)
+    if not allow_non_maximizable and not add_window:isMaximizable() then
         Windows.PaperWM.logger.d("ignoring non-maximizable window")
         return
     end


### PR DESCRIPTION
## why
some apps report windows as non maximizable even though they can still be tiled correctly by PaperWM.
for example, Helium, which hides the standard macOS traffic-light controls in zen mode. Because the window is reported as non maximizable, PaperWM currently ignores it, even though resizing/tiling the window works correctly.

## summary
this adds an optional `allow_non_maximizable_window(window)` hook so users can explicitly opt specific windows into tiling while preserving the existing default behavior.
ex:
```lua
PaperWM.allow_non_maximizable_window = function(window)
    local app = window:application()
    return app and app:bundleID() == "net.imput.helium"
end
```
by default this remains nil, so non maximizable windows continue to be ignored unless users explicitly override the behavior.