### PR TITLE
Tile windows in event handler again

### DIFF
--- a/events.lua
+++ b/events.lua
@@ -104,11 +104,7 @@ function Events.windowEventHandler(window, event, self)
         space = Spaces.windowSpaces(window)[1]
     end
 
-    -- schedule tileSpace in a callback to allow global state, like
-    -- Window:focusedWindow(), to update after this event handler
-    if space then
-        Timer.doAfter(Window.animationDuration, function() self:tileSpace(space) end)
-    end
+    if space then self:tileSpace(space) end
 end
 
 ---coroutine to slide all windows in a space by dx


### PR DESCRIPTION
In #161, you added a delay to `tileSpace`; after updating my PaperWM installation I noticed that window focusing was significantly slower, and MouseFollowsFocus was broken as a result. To me these ergonomics are more important than the fixes you mentioned in #161. Hence, I propose partially reverting that change.