### PR TITLE
feat: add peek_width config

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -74,6 +74,9 @@ Config.window_ratios = { 0.23607, 0.38195, 0.61804 } ---@type number[]
 ---default window width ratio, applied when no app-specific width matches
 Config.default_width = nil ---@type number?
 
+---default peek width
+Config.peek_width = nil ---@type number?
+
 ---default window width by app name or bundle ID
 Config.app_widths = {} ---@type table<string, number>
 

--- a/tiling.lua
+++ b/tiling.lua
@@ -112,8 +112,16 @@ function Tiling.tileSpace(space, anchor_window)
 
     -- get some global coordinates
     local screen_frame <const> = screen:frame()
-    local left_margin <const> = screen_frame.x + Tiling.PaperWM.screen_margin
-    local right_margin <const> = screen_frame.x2 - Tiling.PaperWM.screen_margin
+    
+    -- PEEK WIDTH (new optional feature - backward compatible)
+    local peek = Tiling.PaperWM.peek_width
+    if peek == nil then
+        peek = Tiling.PaperWM.screen_margin or 0
+    end
+
+    local left_margin  <const> = screen_frame.x + peek
+    local right_margin <const> = screen_frame.x2 - peek
+
     local canvas <const> = Tiling.PaperWM.windows.getCanvas(screen)
 
     -- make sure anchor window is on screen


### PR DESCRIPTION
With this new feature you can have the windows left and right just 1px, comes in very handy if you have have padding between the windows.

For me, it's more elegant, but I made it in a way so that it is completely optional.